### PR TITLE
don't claim that rebates will be available this year

### DIFF
--- a/src/incentive-details.ts
+++ b/src/incentive-details.ts
@@ -96,6 +96,9 @@ function formatStartDate(start_date: number, type: IncentiveType) {
     } else {
       return html`${start_date.toString()}`;
     }
+  } else {
+    // while we technically don't expect another IncentiveType, fall back to date here if needed:
+    return html`${start_date.toString()}`;
   }
 }
 


### PR DESCRIPTION
Consistent with the RA Policy team's request for the main RA website calculator, updating the timeline for IRA rebate availability to 2024. For tax credits, I think it's safe to use the `start_date` from the API. For rebates, leaving it hard-coded for now and will follow up with API tickets to make it clearer when things are uncertain.