### PR TITLE
persnickety apostrophes, but only for UI copy

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -47,7 +47,7 @@ describe('template spec', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains("Incentives you're interested in");
+      .contains('Incentives you’re interested in');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()

--- a/src/calculator-form.ts
+++ b/src/calculator-form.ts
@@ -90,8 +90,8 @@ export const formTemplate = (
   gridClass: string = 'grid-3-2',
 ) => {
   const labelSlot = html`<label slot="label">
-    Projects you're most interested in
-    <sl-tooltip content="Select the projects you're most interested in." hoist
+    Projects you’re most interested in
+    <sl-tooltip content="Select the projects you’re most interested in." hoist
       >${questionIcon(tooltipSize, tooltipSize)}</sl-tooltip
     ></label
   >`;
@@ -163,7 +163,7 @@ export const formTemplate = (
           <label for="household_income">
             Household income
             <sl-tooltip
-              content="Enter your gross income (income before taxes). Include wages and salary plus other forms of income, including pensions, interest, dividends, and rental income. If you are married and file jointly, include your spouse's income"
+              content="Enter your gross income (income before taxes). Include wages and salary plus other forms of income, including pensions, interest, dividends, and rental income. If you are married and file jointly, include your spouse’s income."
               hoist
               >${questionIcon(tooltipSize, tooltipSize)}</sl-tooltip
             >

--- a/src/index.html
+++ b/src/index.html
@@ -66,7 +66,7 @@
         This page is a demonstration of our embeddable calculator, intended for
         website owners to add to their own page to help their visitors
         understand the electrification incentives offered as part of the
-        Inflation Reduction Act (IRA). If you're looking to evaluate the impact
+        Inflation Reduction Act (IRA). If you’re looking to evaluate the impact
         of IRA electrification incentives for your own home, please use
         <a href="https://www.rewiringamerica.org/app/ira-calculator"
           >our official IRA Calculator</a

--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -378,7 +378,7 @@ const atAGlanceTemplate = (response: APIResponse) => {
         ${summaryBoxTemplate(
           'Upfront discounts',
           `$${response.savings.pos_rebate.toLocaleString()}`,
-          "Money saved on a project's upfront costs.",
+          'Money saved on a project’s upfront costs.',
         )}
         ${summaryBoxTemplate(
           'Rebates',
@@ -479,7 +479,7 @@ export const stateIncentivesTemplate = (
 
   return html` ${atAGlanceTemplate(response)}
   ${gridTemplate(
-    "Incentives you're interested in",
+    'Incentives you’re interested in',
     selectedIncentives,
     selectedProjects,
     projectTab,

--- a/src/working-copy.html
+++ b/src/working-copy.html
@@ -66,7 +66,7 @@
         This page is a demonstration of our embeddable calculator, intended for
         website owners to add to their own page to help their visitors
         understand the electrification incentives offered as part of the
-        Inflation Reduction Act (IRA). If you're looking to evaluate the impact
+        Inflation Reduction Act (IRA). If you’re looking to evaluate the impact
         of IRA electrification incentives for your own home, please use
         <a href="https://www.rewiringamerica.org/app/ira-calculator"
           >our official IRA Calculator</a


### PR DESCRIPTION
Update to use curly apostrophes in UI copy wherever possible.

Based on feedback on previous PR, not doing this in all the README and comment text.