### PR TITLE
tomc/input font

### DIFF
--- a/src/styles/input.ts
+++ b/src/styles/input.ts
@@ -16,4 +16,8 @@ export const inputStyles = css`
     box-shadow: 0 0 0 2px var(--ra-input-focus-color) inset;
     outline: none;
   }
+
+  input[inputmode='numeric'] {
+    font-variant-numeric: tabular-nums;
+  }
 `;


### PR DESCRIPTION
- use GT America for inputs
- use tabular numbers for numeric inputs

Test plan: inspect the input and check that the font is set to GT America and not the system font.

Closes https://app.asana.com/0/1205057814651000/1205636582326124/f