### PR TITLE
add autocomplete="postal-code" to zip field

### DIFF
--- a/src/calculator-form.ts
+++ b/src/calculator-form.ts
@@ -139,6 +139,7 @@ export const formTemplate = (
             maxlength="5"
             inputmode="numeric"
             pattern="[0-9]{5}"
+            autocomplete="postal-code"
           />
         </div>
         <div>


### PR DESCRIPTION
I'm led to believe that this is all that's required to get modern browsers to offer suggested completions for zip codes.

HOWEVER, I can't get it to work locally in Safari.

When I disabled 1password in Chrome and added an address to the address book I did get it to do this:
![Screenshot 2023-10-02 at 5 29 55 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/98d8c339-9621-48f0-a621-bfe5e9e0070c)

It doesn't do this without the `autocomplete` attribute so I think that's progress?

I have a theory that Safari will work when it's not on localhost. Will check the preview build.

Closes https://app.asana.com/0/0/1205636787130044/f