### PR TITLE
Polish form grid

### DIFF
--- a/src/calculator-form.ts
+++ b/src/calculator-form.ts
@@ -29,6 +29,10 @@ const buttonStyles = css`
     background-color: var(--ra-embed-primary-button-background-hover-color);
   }
 
+  .grid-right-column {
+    grid-column: -2 / -1;
+  }
+
   /* shoelace style overrides */
   sl-tooltip {
     --max-width: var(--ra-tooltip-max-width);
@@ -220,7 +224,7 @@ export const formTemplate = (
             tabIndex: 0,
           })}
         </div>
-        <div>
+        <div class="grid-right-column">
           <button class="primary" type="submit">
             ${calculateButtonContent}
           </button>

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -299,7 +299,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
                   calculateButtonContent,
                 },
                 (event: SubmitEvent) => this.submit(event),
-                'grid-3-2-1',
+                'grid-2-2-1',
               )}
         </div>
         ${

--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -114,18 +114,21 @@ export const stateIncentivesStyles = css`
     white-space: nowrap;
   }
 
+  .grid-2-2-1,
   .grid-3-2-1,
   .grid-4-2-1 {
     display: grid;
     gap: 1rem;
     align-items: end;
   }
+  .grid-2-2-1--align-start,
   .grid-3-2-1--align-start,
   .grid-4-2-1--align-start {
     align-items: start;
   }
 
   @media only screen and (max-width: 640px) {
+    .grid-2-2-1,
     .grid-3-2-1,
     .grid-4-2-1 {
       grid-template-columns: 1fr;
@@ -133,6 +136,7 @@ export const stateIncentivesStyles = css`
   }
 
   @media only screen and (min-width: 641px) and (max-width: 768px) {
+    .grid-2-2-1,
     .grid-3-2-1,
     .grid-4-2-1 {
       grid-template-columns: 1fr 1fr;
@@ -140,6 +144,9 @@ export const stateIncentivesStyles = css`
   }
 
   @media only screen and (min-width: 769px) {
+    .grid-2-2-1 {
+      grid-template-columns: 1fr 1fr;
+    }
     .grid-3-2-1 {
       grid-template-columns: 1fr 1fr 1fr;
     }


### PR DESCRIPTION
## Description

- The design spec has a 2-column grid on wide and medium layouts, so
  do that.

- Pin the Calculate button to the right-hand column. This will prevent
  it from jumping around when we add the email field (#37) which
  disappears after form submission.

How did people do anything before grid and flexbox were invented??

Closes https://app.asana.com/0/1205057814651000/1205636582326127

## Test Plan

Make sure the button is on the right, with an empty space to its
left. Make sure it looks the same as before on narrow (1-column)
layout.

Add another div before the button; make sure it fills in the space to
the left of the button.
