### PR TITLE
set max width on utility selector card and map

### DIFF
--- a/src/utility-selector.ts
+++ b/src/utility-selector.ts
@@ -12,6 +12,7 @@ export const utilitySelectorStyles = css`
   .utility-selector__map {
     position: relative;
     text-align: center;
+    max-width: 100%;
   }
 
   .utility-selector__map svg {
@@ -52,6 +53,7 @@ export const utilitySelectorStyles = css`
     .utility-selector .card {
       /* Margin is provided by the outer element */
       margin: 0;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
On small phones, current `main` looks like this:
![Screenshot 2023-10-03 at 9 14 07 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/15f9a45c-eda0-46ea-96d8-e59f265e537c)

With this PR, it looks like this:
![Screenshot 2023-10-03 at 9 19 31 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/21f2ed2e-f7b0-426a-a53c-b875c244e2f2)

And on this PR, larger screens still look good:
![Screenshot 2023-10-03 at 9 13 50 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/cd3e079b-05a4-4032-aa50-29fb21d86cc1)


