### PR TITLE
Handle updated /utilities response format

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -52,11 +52,25 @@ export interface Incentive {
   eligible: boolean;
 }
 
-export type APIUtilitiesResponse = {
-  [utilityId: string]: {
-    name: string;
-  };
-};
+export interface APILocation {
+  state: string;
+}
+
+// TODO delete the first option once API PR #161 is deployed to prod
+export type APIUtilitiesResponse =
+  | {
+      [utilityId: string]: {
+        name: string;
+      };
+    }
+  | {
+      location: APILocation;
+      utilities: {
+        [utilityId: string]: {
+          name: string;
+        };
+      };
+    };
 
 export interface APIResponse {
   authorities: {

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -206,12 +206,17 @@ export class RewiringAmericaStateCalculator extends LitElement {
       });
 
       try {
-        const utilityMap = await fetchApi<APIUtilitiesResponse>(
+        const response = await fetchApi<APIUtilitiesResponse>(
           this.apiKey,
           this.apiHost,
           '/api/v1/utilities',
           query,
         );
+
+        const utilityMap =
+          'utilities' in response
+            ? (response.utilities as Record<string, { name: string }>)
+            : response;
 
         return Object.keys(utilityMap).map(id => ({
           value: id,


### PR DESCRIPTION
## Description

rewiringamerica/api.rewiringamerica.org#161 will change the format of
the `/utilities` response in a backward-incompatible way, so
temporarily make the frontend able to handle both formats.

This relies on there being no utility with the ID `utilities`.

### Followup

Once the API change is deployed to prod, I'll follow up by removing
the adaptation, and also reworking the frontend logic to (a) implement
locking to one state and (b) remove the `tempState` hack.

## Test Plan

Run this against my local API server with the change applied, and
against prod. Make sure the utility selector is populated correctly in
both cases.
