### PR TITLE
Fix incentive details to only display eligible incentives.

### DIFF
--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -451,27 +451,27 @@ export const stateIncentivesTemplate = (
       allEligible.filter(i => info.items.includes(i.item.type)),
     ]),
   ) as Record<Project, Incentive[]>;
-  const eligibleProjects = (
+  const projectsWithIncentives = (
     Object.entries(incentivesByProject) as [Project, Incentive[]][]
   )
     .filter(([, incentives]) => incentives.length > 0)
     .map(([project]) => project);
 
-  const eligibleSelectedProjects = selectedProjects
-    .filter(project => eligibleProjects.includes(project))
+  const interestedProjects = selectedProjects
+    .filter(project => projectsWithIncentives.includes(project))
     .sort((a, b) => shortLabel(a).localeCompare(shortLabel(b)));
-  const eligibleNonSelectedProjects = eligibleProjects
-    .filter(project => !eligibleSelectedProjects.includes(project))
+  const otherProjects = projectsWithIncentives
+    .filter(project => !interestedProjects.includes(project))
     .sort((a, b) => shortLabel(a).localeCompare(shortLabel(b)));
 
   const projectTab =
-    selectedProjectTab && eligibleSelectedProjects.includes(selectedProjectTab)
+    selectedProjectTab && interestedProjects.includes(selectedProjectTab)
       ? selectedProjectTab
-      : eligibleSelectedProjects[0];
+      : interestedProjects[0];
   const otherTab =
-    selectedOtherTab && eligibleNonSelectedProjects.includes(selectedOtherTab)
+    selectedOtherTab && otherProjects.includes(selectedOtherTab)
       ? selectedOtherTab
-      : eligibleNonSelectedProjects[0];
+      : otherProjects[0];
 
   const selectedIncentives = incentivesByProject[projectTab] ?? [];
   const selectedOtherIncentives = incentivesByProject[otherTab] ?? [];
@@ -485,14 +485,14 @@ export const stateIncentivesTemplate = (
   ${gridTemplate(
     'Incentives you’re interested in',
     selectedIncentives,
-    eligibleSelectedProjects,
+    interestedProjects,
     projectTab,
     onTabSelected,
   )}
   ${gridTemplate(
     otherIncentivesLabel,
     selectedOtherIncentives,
-    eligibleNonSelectedProjects,
+    otherProjects,
     // If a nonexistent tab is selected, pretend the first one is selected.
     otherTab,
     onOtherTabSelected,


### PR DESCRIPTION
Given certain inputs, the incentive details displayed will disappear if you click on an incentive that isn't eligible for the user.

IE, with these sets of inputs, if you clicked on "Cooking" or "Clothes Dryer", all the incentives will disappear.

<img width="1163" alt="Screenshot 2023-10-05 at 1 17 12 PM" src="https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/7633466/df92abd7-ec65-4e04-bacb-4c9f794fc385">

<img width="1193" alt="Screenshot 2023-10-05 at 1 18 48 PM" src="https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/7633466/25e93a52-edf7-4db8-98b5-0e5e4dce3331">

<img width="1189" alt="Screenshot 2023-10-05 at 1 19 03 PM" src="https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/7633466/23575f77-0afa-4002-9363-7bc318331143">
