### PR TITLE
Apply hover styling to Calculate button on focus

### DIFF
--- a/src/calculator-form.ts
+++ b/src/calculator-form.ts
@@ -26,7 +26,8 @@ const buttonStyles = css`
     width: 100%;
   }
 
-  button.primary:hover {
+  button.primary:hover,
+  button.primary:focus {
     background-color: var(--ra-embed-primary-button-background-hover-color);
   }
 


### PR DESCRIPTION
This is Tom's suggestion from the a11y review doc: style the button as
if it's being hovered when it's focused, with the darker purple
background. I think we're considering this a stopgap until we get a
specific design for focus state.

https://app.asana.com/0/1205057814651000/1205636787130046

## Test Plan

Hit Tab until the button is focused; verify that it gets a slightly
darker purple background, and no focus ring.
