### PR TITLE
Improve pill button accessibility

### DIFF
--- a/src/icon-tab-bar.ts
+++ b/src/icon-tab-bar.ts
@@ -96,6 +96,9 @@ export const iconTabBarTemplate = (
     return html`
       <button
         class="${classes('icon-tab')}"
+        role="tab"
+        aria-selected="${isSelected}"
+        aria-label="${PROJECTS[project].label}"
         @click=${() => onTabSelected(project)}
       >
         ${PROJECTS[project].icon(isSelected)}
@@ -113,7 +116,7 @@ export const iconTabBarTemplate = (
   }));
 
   return html`
-    <div class="icon-tab-bar">${iconTabs}</div>
+    <div class="icon-tab-bar" role="tablist">${iconTabs}</div>
     <div class="icon-dropdown">
       ${select({
         id: 'project-selector',


### PR DESCRIPTION
This solves two problems:

- Screen readers couldn't identify which button was selected, since it
  was indicated purely visually. Fix this by giving the pills the
  `tab` role and using `aria-selected`.

  Additionally, giving the enclosing div the `tablist` role lets the
  screen reader know how many tabs there are and which one you're
  looking at.

  There's possible further work here, involving giving the `tabpanel`
  role to the div that corresponds to the content of each tab. That
  doesn't seem to be necessary to solve the immediate problem.

- The abbreviations like "HVAC" were not handled well by screen
  readers (VoiceOver pronounces this, and "EV", as if they were words,
  like "huhvack"). These also didn't correspond to the announced names
  of projects in the top-level form. Add an `aria-label` to the pill
  button containing the long version of the project.

https://app.asana.com/0/1205057814651000/1205636787130043
https://app.asana.com/0/1205057814651000/1205636787130047

## Test Plan

Using VoiceOver on Mac, navigate a row of pills. Make sure the
selected one is announced as "selected", and their index is announced
(e.g. "1 of 3"). Choose the ones for HVAC and EV and make sure the
full versions are announced ("heating ventilation and cooling" and
"electric vehicle").
