### PR TITLE
Fix Cypress test

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -55,7 +55,7 @@ describe('template spec', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('$1,250/ton off a heat pump');
+      .contains('$1,000/ton off a heat pump');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()


### PR DESCRIPTION
It was looking for a string that's derived from the live API response,
and that string has changed (the amount of the Clean Heat RI heat pump
incentive).

This kind of thing is going to keep happening, and I'm not sure
there's a great solution for it. I'm sure there's a way to mock out
API responses during Cypress testing, but that would mean not testing
that the frontend code can handle live API responses.

## Test Plan

`yarn cypress:run` passes
