### PR TITLE
Fix behavior of submitting the form while income is blank

### DIFF
--- a/src/currency-input.ts
+++ b/src/currency-input.ts
@@ -46,24 +46,14 @@ export class CurrencyInput extends LitElement {
     }
   }
 
-  onKeydown(event: KeyboardEvent) {
-    // this simulates submit on the host form, just like if you hit Enter in a regular <input>
-    if (event.key === 'Enter') {
-      const element: CurrencyInput = event.target as CurrencyInput;
-      element.internals?.form?.requestSubmit();
-    }
-  }
-
   override connectedCallback() {
     super.connectedCallback();
     this.internals = this.attachInternals();
     this.internals?.setFormValue(this.value);
-    this.addEventListener('keydown', this.onKeydown);
   }
 
   override disconnectedCallback() {
     this.autonumeric?.detach();
-    this.removeEventListener('keydown', this.onKeydown);
     super.disconnectedCallback();
   }
 
@@ -92,6 +82,10 @@ export class CurrencyInput extends LitElement {
 
   updateAutonumericOptions() {
     this.autonumeric?.update({
+      // Prevent autonumeric from populating the field with "$" when focusing
+      // it while empty. (That would suppress the browser's "fill out this
+      // field" indicator.)
+      emptyInputBehavior: 'press',
       minimumValue: this.min.toString(),
       maximumValue: this.max.toString(),
       decimalPlaces: 0,


### PR DESCRIPTION
## Description

The symptom was that submitting the form without a value for household
income would focus the income field but not show the "fill out this
field" indicator that browsers show for `required` input fields that
aren't filled out on submit. From this symptom I went on a whole
journey that had me deep in the [Autonumeric source](https://github.com/autonumeric/autonumeric).

What was happening was this:

1. You submit the form while the field is blank.

2. The browser sees the `required` field is blank. It focuses the
   field and queues up the "fill out this field" indicator.

3. Autonumeric's `focus` event handler runs, which, with the default
   setting of `emptyInputBehavior`, causes it to populate the field
   with `$`.

4. The browser perceives this as the field being filled in, so it
   cancels the indicator and the user never sees it.

After a ton of experimentation, I found that changing the
`emptyInputBehavior` setting to `press` gives _almost_ the right
behavior. Don't ask me what `press` is supposed to mean; it's not
documented. Anyway, this way, when you focus the field while it's
empty, it stays empty. And when focus leaves the field while it just
has a `$` in it, it becomes empty.

One tiny corner of bad behavior remained: if you hit Enter in the
field while the field's contents are just `$` (which is only possible
by typing a number and then deleting the digits), the submission would
go ahead and then the UI would get stuck in a weird state. It turned
out this was due to the `keyDown` handler forcing the form submission.
It doesn't actually seem to be necessary -- if I remove it, the form
still submits upon hitting Enter from the income field.

## Test Plan

1. Submit the form while the field is populated and make sure the
   displayed value goes to the API.

1. Delete everything in the field, except the `$` (which Autonumeric
   won't let you delete). With the field focused, hit Enter; make sure
   the field stays focused, goes blank, and gets the indicator.

1. Same as the last step, but click the button to submit instead of
   hitting Enter.

1. Type a number into the field, then backspace until there's just a
   dollar sign left, then shift-Tab twice to go back to the zip
   field. Hit Enter (or click the button) and make sure the income
   field gets focused, goes blank, and gets the indicator.

Tested the above in Brave, Safari, Firefox, and MobileSafari.
