### PR TITLE
Scroll down when loading completes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "@shoelace-style/shoelace": "^2.11.0",
     "autonumeric": "^4.8.1",
     "element-internals-polyfill": "^1.3.4",
-    "lit": "^2.6.1"
+    "lit": "^2.6.1",
+    "scroll-into-view-if-needed": "^3.1.0"
   },
   "scripts": {
     "build:widget": "NODE_ENV=production parcel build --target default",

--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -328,6 +328,7 @@ const incentiveCardTemplate = (incentive: Incentive) => html`
 
 const gridTemplate = (
   heading: string,
+  htmlId: string,
   incentives: Incentive[],
   tabs: Project[],
   selectedTab: Project,
@@ -335,7 +336,7 @@ const gridTemplate = (
 ) =>
   tabs.length > 0 && incentives.length > 0
     ? html`
-        <div class="grid-section">
+        <div class="grid-section" id="${htmlId}">
           <h2 class="grid-section__header">${heading}</h2>
           ${iconTabBarTemplate(tabs, selectedTab, onTabSelected)}
           <div class="grid-3-2-1 grid-3-2-1--align-start">
@@ -402,6 +403,7 @@ export const stateIncentivesTemplate = (
 
   return html`${gridTemplate(
     'Incentives you’re interested in',
+    'interested-incentives',
     selectedIncentives,
     interestedProjects,
     projectTab,
@@ -409,6 +411,7 @@ export const stateIncentivesTemplate = (
   )}
   ${gridTemplate(
     otherIncentivesLabel,
+    'other-incentives',
     selectedOtherIncentives,
     otherProjects,
     // If a nonexistent tab is selected, pretend the first one is selected.

--- a/src/utility-selector.ts
+++ b/src/utility-selector.ts
@@ -120,7 +120,7 @@ export const utilitySelectorTemplate = (
   utilities: APIUtilityMap,
   onChange: (utilityId: string) => void,
 ) =>
-  html` <div class="utility-selector">
+  html` <div class="utility-selector" id="utility-selector">
     <div class="utility-selector__map">
       ${stateInfo.icon()}
       <h1 class="utility-selector__title">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,6 +1680,11 @@ composed-offset-position@^0.0.4:
   resolved "https://registry.yarnpkg.com/composed-offset-position/-/composed-offset-position-0.0.4.tgz#ca8854abf15e3c235ecf4df125a27fe88af76ea4"
   integrity sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw==
 
+compute-scroll-into-view@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz#753f11d972596558d8fe7c6bcbc8497690ab4c87"
+  integrity sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -3525,6 +3530,13 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+scroll-into-view-if-needed@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz#fa9524518c799b45a2ef6bbffb92bcad0296d01f"
+  integrity sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==
+  dependencies:
+    compute-scroll-into-view "^3.0.2"
 
 semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"


### PR DESCRIPTION
## Description

This was one of the most consistent results of UXR: especially on
mobile, people would think nothing had happened after hitting
Calculate. Scrolling down to the results is the quickest way of fixing
that.

https://app.asana.com/0/1205057814651000/1205571641895785

## Test Plan

- Submit with zip = 02814 to get multiple utility options. Make sure
  the first load scrolls to the utility selector. Change the utility
  selector and make sure it scrolls down to the incentives on load.

- With `state="RI"` on the calculator component, enter a zip from
  another state, and make sure it scrolls to the "that ZIP is not in
  RI" error message on load.

- Without `state="RI"`, enter a zip from another state, and make sure
  it scrolls to the incentives on load (there's no utility selector).

- Use the project pills (or dropdowns) and make sure no scrolling
  happens.
