### PR TITLE
Remove hide-form and hide-details attributes

### DIFF
--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -169,14 +169,6 @@ export class RewiringAmericaStateCalculator extends LitElement {
   @property({ type: String, attribute: 'lang' })
   override lang: string = this.getDefaultLanguage();
 
-  /* supported properties to control showing/hiding of each card in the widget */
-
-  @property({ type: Boolean, attribute: 'hide-form' })
-  hideForm: boolean = false;
-
-  @property({ type: Boolean, attribute: 'hide-details' })
-  hideDetails: boolean = false;
-
   /* supported property to show the email signup field */
 
   @property({ type: Boolean, attribute: 'show-email' })
@@ -506,26 +498,24 @@ export class RewiringAmericaStateCalculator extends LitElement {
               </button>
             </div>
           </div>
-          ${this.hideForm
-            ? nothing
-            : formTemplate(
-                [
-                  this.zip,
-                  this.ownerStatus,
-                  this.householdIncome,
-                  this.taxFiling,
-                  this.householdSize,
-                ],
-                this.projects,
-                {
-                  showEmailField: this.showEmail && !this.wasEmailSubmitted,
-                  showProjectField: true,
-                  tooltipSize: 13,
-                  calculateButtonContent,
-                },
-                (event: SubmitEvent) => this.submit(event),
-                'grid-2-2-1',
-              )}
+          ${formTemplate(
+            [
+              this.zip,
+              this.ownerStatus,
+              this.householdIncome,
+              this.taxFiling,
+              this.householdSize,
+            ],
+            this.projects,
+            {
+              showEmailField: this.showEmail && !this.wasEmailSubmitted,
+              showProjectField: true,
+              tooltipSize: 13,
+              calculateButtonContent,
+            },
+            (event: SubmitEvent) => this.submit(event),
+            'grid-2-2-1',
+          )}
         </div>
         ${
           // This is defensive against the possibility that the backend and


### PR DESCRIPTION
## Description

`hide-form` made the calculator unusable, since it hid the Calculate
button and there's no other way to make the calculator calculate.
`hide-details` didn't do anything at all.

We're removing these until there's a concrete need for them, then
we'll design for that.

## Test Plan

Look at calculator
