### PR TITLE
Rewrite README for open source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Developer Guide
+
+This is a guide to contributing to this codebase. It's intended both for Rewiring America engineers and external contributors.
+
+## Getting Started
+
+First, read the [README](README.md), especially the [running/building](README.md#running--building) section to get the calculator running locally.
+
+## Codebase overview
+
+All the code is TypeScript, and is required to typecheck without errors.
+
+- One of the major design constraints in this codebase is the need to embed the component on third-party sites. We strive to keep the bundle size down by taking few dependencies and trying to keep them small. Among other things, that's why we don't use React.
+
+- The component framework is [Lit](https://lit.dev/docs/v2/). We use [@lit/task](https://github.com/lit/lit/blob/HEAD/packages/task/README.md) to manage fetching from the API.
+
+- The build system is [Parcel](https://parceljs.org). In addition to building the [embed demo site](https://embed.rewiringamerica.org), it builds the file `src/state-calculator.ts` and all of its transitive dependencies into a single `.js` file. That file is hosted on `embed.rewiringamerica.org` and referenced from third-party pages that include the embed.
+
+  - The CSS font-face does not seem to apply if fonts are loaded by the Shadow DOM's styles, so we build a separate font stylesheet that embed clients reference.
+
+- We use some components from [Shoelace](https://shoelace.style/).
+
+### Accessibility
+
+- To allow this calculator to be embedded on state government websites, we require compliance with WCAG 2.1 level AA accessibility guidelines.
+
+- We use `cypress-axe` to maintain a baseline of automated conformance, and periodically review against a [Voluntary Product Accessibility Template](https://www.itic.org/policy/accessibility/vpat) for steps that can only be assessed manually.
+
+- Any significant UI changes or additions will need to be manually reviewed against the VPAT.
+
+### Internationalization
+
+- The new frontend is localized into Spanish. Ideally, any new user-visible strings should be translated into Spanish before landing.
+
+- It's acceptable to use machine translation, but any machine-translated output should be reviewed by a fluent human Spanish speaker before landing.
+
+- We use [@lit/localize](https://lit.dev/docs/localization/overview/) to extract strings and select translations at runtime. The source of truth for translations is the file `translations/es.xlf`.
+
+## Branching
+
+- All PRs should be branches off of `main`.
+- Vercel makes a preview deploy for every PR, and comments on the PR with a link.
+- PRs should be landed by "squash and merge". We don't like merge commits or cluttered history.
+- There should not be long-lived feature branches.
+- Anything landed on `main` **is deployed to production immediately**.
+  - In particular, this means third-party sites with the embed will reflect changes landed on `main` **immediately**. Be careful!
+
+## Code review
+
+All PRs are code-reviewed and require at least one approval from a repo committer (which currently includes RA staff only) before merging. PR authors merge their own PRs once they're approved and tests are passing.
+
+To speed things up, we sometimes "approve with comments": approving but pointing out minor things that we trust the author to fix before merging, or that we leave up to the author's discretion. After fixing (or not fixing) such things, the author is free to merge without further review. (However, they can request another review if they want.)
+
+## Tests
+
+There are a few basic [Cypress](https://cypress.io) tests defined in `cypress/e2e`. They include a basic accessibility check using `cypress-axe`. The tests are run for every PR, and are required to pass before the PR can land.
+
+Note that the Cypress tests are using the live production API, not a mock. It's possible for them to fail because of non-breaking API changes, unrelated to changes in this codebase (for example, if a test is looking for a specific string on the page).
+
+We use Prettier and ESLint; both are run for every PR and are required to report no issues. We recommend setting up your editor to run Prettier automatically on save.

--- a/README.md
+++ b/README.md
@@ -1,93 +1,103 @@
-# Overview
+# Rewiring America Embeddable Incentives Calculator
 
-Takes functionality from our [public website calculator](https://www.rewiringamerica.org/app/ira-calculator) and packages it up in a custom web component built using `lit`. Lit's `Task` library takes care of watching the form parameters for changes
-and fetching data from our API.
+This is a custom web component that renders a calculator for home electrification incentives. Users input some information about themselves, and the calculator shows incentives --- tax credits, rebates, etc. --- that they're eligible for.
 
-**Note:** API keys are required, sign up on our [API homepage](https://www.rewiringamerica.org/api).
+The calculator can be embedded on third-party websites. An instance of it is available on [Rewiring America's website](https://homes.rewiringamerica.org/calculator).
 
-# Documentation
+In addition to the calculator itself, this repo contains a small website that demonstrates the component. It's hosted at `https://embed.rewiringamerica.org`.
 
-- [Embed usage](https://api.rewiringamerica.org/docs/v0/embed)
-- [Calculator examples](https://glitch.com/~rewiring-america-calculator-widget)
+## Usage
 
-# Development
+To embed the calculator on your website:
 
-- Get an incentives API key, and put it in a local file `.env.local` like so:
-  ```
-  REWIRING_AMERICA_API_KEY=zpka_********************************_********
-  ```
-  You can also set that as an environment variable, if you prefer.
-- `yarn` to install dependencies
-- `yarn serve:widget` and open `http://localhost:1234/` to start working - should refresh when files change
-- Open `http://localhost:1234/working-copy.html` to test against the dev API service
-- `yarn build:widget` to build the deployment artifacts (Vercel does this for production deploys)
+1. Sign up for the [Rewiring America API](https://www.rewiringamerica.org/api) and get an API key.
 
-# Styles
+2. Add the following to your page's `<head>` tag:
 
-For better or worse, using BEM to keep CSS manageable. This may be overkill since LitElement encapsulates the styles for us already.
+   ```html
+   <script
+     type="module"
+     src="https://embed.rewiringamerica.org/state-calculator.js"
+   ></script>
+   <link
+     rel="stylesheet"
+     type="text/css"
+     href="https://embed.rewiringamerica.org/rewiring-fonts.css"
+   />
+   ```
 
-The CSS font-face does not seem to apply if fonts are loaded by the Shadow DOM's styles, so a separate font stylesheet is provided for these.
+3. Add the following in the body of the page:
 
-# Accessibility
+   ```html
+   <rewiring-america-state-calculator api-key="YOUR_API_KEY">
+   </rewiring-america-state-calculator>
+   ```
 
-To allow this calculator to be embedded on state government websites, we require compliance with WCAG 2.1 AA accessibility guidelines.
-We use `cypress-axe` to maintain a baseline of automated conformance, and periodically review against a
-[Voluntary Product Accessibility Template](https://www.itic.org/policy/accessibility/vpat) for steps that can only be assessed manually.
-Any significant UI changes or additions will need to be manually reviewed against the VPAT.
+The calculator conforms to WCAG 2.1 level AA.
 
-# Hosting
+### Optional Attributes
 
-This site is deployed using the [embed-rewiring-america](https://vercel.com/rewiring-america/embed-rewiringamerica-org) project on Vercel. The domain `embed.rewiringamerica.org` points to Vercel and is [configured in Google Domains](https://domains.google.com/registrar/rewiringamerica.org/dns).
+The calculator component supports the following attributes to customize its behavior.
 
-# TODO
+| Attribute          | Type            | Description                                                                                                                                  | Default                                           |
+| ------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `lang`             | string          | The language of user-visible text. `en` (English) and `es` (Spanish) are supported. Any other value will fall back to English.               | `lang` from nearest DOM ancestor, or `en` if none |
+| `state`            | 2-letter string | Two-letter state code (e.g. `RI`, `CO`). If set, the calculator will show an error message if the user inputs a location outside that state. | none                                              |
+| `zip`              | 5-digit string  | A ZIP code to pre-populate in the form.                                                                                                      | none                                              |
+| `owner-status`     | string          | A homeowner/renter status to pre-populate in the form.<br/>Valid values: `homeowner`, `renter`                                               | `homeowner`                                       |
+| `household-income` | number          | A household income to pre-populate in the form.                                                                                              | `0`                                               |
+| `tax-filing`       | string          | A tax-filing status to pre-populate in the form.<br/>Valid values: `single`, `joint`, `married_filing_separately`, `hoh`                     | `single`                                          |
+| `household-size`   | number          | A household size to pre-populate in the form. <br/>Valid values: 1 through 8 inclusive                                                       | `1`                                               |
 
-Features and content:
+Values are pre-populated from attributes on page load, and when the user clicks "Reset calculator".
 
-- [x] Add remaining guidance and disclaimer copy for <80% and >150% AMI.
-- [ ] Add reset button to form?
-- [ ] Switch order of incentives depending on whether credits/rebates are more useful.
-- [x] Add currency formatting to the income input element. Using [autonumeric](http://autonumeric.org), which is large.
-- [ ] Consider [Inputmask](https://robinherbots.github.io/Inputmask/#/documentation/numeric) in future.
-- [x] Use a better tooltip component to ensure tooltips are readable at mobile breakpoints. Trying Shoelace's [tooltip](https://shoelace.style/components/tooltip).
-- [ ] Think about how the 'back to calculator' links should work on RA's detail pages ([example](https://www.rewiringamerica.org/app/ira-calculator/information/electrical-panel))
-- [ ] Add analytics support (Amplitude events?)
-- [ ] Add support for Spanish translations.
-- [ ] Send javascript events for calculate, results, project details clicks.
+## Running / building
 
-Robustness:
+### Run a development server
 
-- [x] Take a copy of fonts and serve them from this domain.
-- [ ] Port to API v1's calculator endpoint.
-- [ ] Add slots to allow customizing the form intro text.
-- [x] Add UI tests with Cypress, run in CI.
-- [ ] Add unit tests, run in CI.
-- [ ] How do we handle versioning?
-- [ ] Work with Zuplo to add `origin` configs to API keys and prevent use of API keys outside specific hosts.
-- [ ] Generate types (and API client?) automatically from OpenAPI file.
-- [x] Protect main branch, require PRs.
+1. Get an API key for the Rewiring America incentives API by [signing up here](https://www.rewiringamerica.org/api). (RA employees: ask internally.)
 
-Optimizations:
+2. Put the API key in a file called `.env.local` at the root of your working copy, as follows:
 
-- [ ] Add support for caching results in localStorage.
-- [ ] Add support for showing default list of incentives (from `/api/v0/incentives`).
-- [ ] Reuse microcopy from Rewiring America's CMS to avoid duplication between this repo and our website.
+   ```
+   REWIRING_AMERICA_API_KEY=zpka_********************************_********
+   ```
 
-Roadmap:
+3. Install Node 18. We recommend using [NVM](https://github.com/nvm-sh/nvm).
+4. Install Yarn by running `corepack enable`.
+5. Run `yarn install` to install dependencies.
+6. Run `yarn serve:widget` to run a local server that serves the embed demo website. Access it at `http://localhost:1234`.
 
-- [ ] Open source?
-- [ ] Do we need a way to filter the kinds of incentives offered?
-- [ ] Query by address for v1?
-- [ ] Respond to customer requests for customization/functionality.
+### Build for embedding
 
-Bugs:
+1. Run `yarn build:widget` to build a single `.js` file containing the calculator and all of its transitive dependencies.
 
-- [ ] Clicking the tooltip for Household Income should focus the input. Do we need `delegatesFocus` or do we need to refactor the input into a slot so it's light DOM?
-- [ ] Tapping the tooltip on mobile probably shouldn't select the field. Move outside the label maybe?
+2. The bundled file is written to `dist/state-calculator.js`. This file and `dist/rewiring-fonts.css` are all that's needed to embed the calculator on any webpage.
 
-# References
+## Roadmap
 
-- [Lit](https://lit.dev)
-- [Lit Task](https://github.com/lit/lit/tree/main/packages/labs/task)
-- [Rewiring America API](https://api.rewiringamerica.org/docs/)
-- [BEM](https://getbem.com/introduction/)
-- [Shoelace](https://shoelace.style)
+This codebase doesn't have a significant roadmap of its own. Changes here are primarily driven by the needs of our broader incentives API / calculator project. As the API expands to incentives with more complex structures, this frontend will evolve to match.
+
+There are a few tasks specific to this codebase that we're interested in:
+
+- Automatically generating `src/api/calculator-types-v1.ts` from the [API spec](https://api.rewiringamerica.org/spec.json), rather than manually maintaining it.
+
+- Using [Tailwind](https://tailwindcss.com/) for CSS.
+
+- Better test coverage, including tests that mock out API responses.
+
+### Deprecating old frontend
+
+This codebase actually contains two calculator frontends: one centered in `src/calculator.ts` and one centered in `src/state-calculator.ts`. **The former is soon to be deprecated and should not be used anymore**. It only has support for federal incentives from the Inflation Reduction Act. The latter has support for incentives from states and utilities, and is where all new development is happening.
+
+## Contributing
+
+If you find an inaccuracy in **incentive information**, please see our [incentive API repo](https://github.com/rewiringamerica/api.rewiringamerica.org) for what to do.
+
+If you find a visual, behavioral, or accessibility bug in the _new_ calculator frontend (that is, the one that looks like [this](https://homes.rewiringamerica.org/calculator)), please file an issue in this repo. (The old frontend is soon to be deprecated, so there's no need to file issues for it.)
+
+If you have a feature request for the new frontend, please file it as an issue. We can't make promises of when or if we'll get to it, but we are interested to hear what people want from this project.
+
+We aren't ruling out accepting external code contributions, but we'd like to discuss it before you put too much work into a PR. The best place to have that discussion is in an issue on this repo, but you can also email us at `api@rewiringamerica.org`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for a guide to the codebase.


### PR DESCRIPTION
## Description

This is a from-scratch rewrite of the README, with the target audience
of an external developer or potential consumer of the API. There's
also a CONTRIBUTING.md with a guide to the codebase. Information
specific to RA's deployment of the code has been moved to our Notion
instance, linked from the "Incentives / Savings Calculator" page.

I'm going with a slightly different stance on contributions for this
repo. There's more possible work here that doesn't intersect with our
internal incentives data roadmap, so I'm saying we're tentatively open
to external PRs. I'm also saying we want feature requests; I think
this is a more sensible and likely venue for those than the incentives API.

I'll follow up with a license file and issue templates for bug reports
and feature requests.

## Test Plan

Read it
