### PR TITLE
Type safety for SafeLocalStorage

### DIFF
--- a/src/email-signup.ts
+++ b/src/email-signup.ts
@@ -2,6 +2,12 @@ import { safeLocalStorage } from './safe-local-storage';
 
 const LOCAL_STORAGE_KEY = 'RA-calc-email-submitted';
 
+declare module './safe-local-storage' {
+  interface SafeLocalStorageMap {
+    [LOCAL_STORAGE_KEY]: boolean;
+  }
+}
+
 export function wasEmailSubmitted(): boolean {
   return safeLocalStorage.getItem(LOCAL_STORAGE_KEY) !== null;
 }

--- a/src/safe-local-storage.ts
+++ b/src/safe-local-storage.ts
@@ -1,9 +1,24 @@
 /**
+ * Augment this interface with a property whose name is the local storage key,
+ * and whose type is the type of the values you will store under that key.
+ *
+ * declare module './safe-local-storage' {  // or however you import this
+ *   interface SafeLocalStorageMap {
+ *     'my-key': MyType
+ *   }
+ * }
+ */
+export interface SafeLocalStorageMap {}
+
+/**
  * A wrapper around window.localStorage that silences errors and handles JSON
  * encoding/decoding.
  */
 class SafeLocalStorage {
-  setItem<T>(key: string, value: T) {
+  setItem<T extends keyof SafeLocalStorageMap>(
+    key: T,
+    value: SafeLocalStorageMap[T],
+  ) {
     try {
       localStorage.setItem(key, JSON.stringify(value));
     } catch (_) {
@@ -11,7 +26,9 @@ class SafeLocalStorage {
     }
   }
 
-  getItem<T>(key: string): T | null {
+  getItem<T extends keyof SafeLocalStorageMap>(
+    key: T,
+  ): SafeLocalStorageMap[T] | null {
     try {
       const value = localStorage.getItem(key);
       return value ? JSON.parse(value) : null;
@@ -20,7 +37,7 @@ class SafeLocalStorage {
     }
   }
 
-  removeItem(key: string) {
+  removeItem(key: keyof SafeLocalStorageMap) {
     try {
       localStorage.removeItem(key);
     } catch (_) {

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -126,6 +126,12 @@ type SavedFormValues = Partial<{
   projects: Project[];
 }>;
 
+declare module './safe-local-storage' {
+  interface SafeLocalStorageMap {
+    [FORM_VALUES_LOCAL_STORAGE_KEY]: SavedFormValues;
+  }
+}
+
 const formTitleStyles = css`
   .form-title {
     display: flex;
@@ -253,9 +259,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
    * otherwise.
    */
   initFormProperties(): void {
-    const formValues = safeLocalStorage.getItem<SavedFormValues>(
-      FORM_VALUES_LOCAL_STORAGE_KEY,
-    );
+    const formValues = safeLocalStorage.getItem(FORM_VALUES_LOCAL_STORAGE_KEY);
     const attr = (k: string) => this.attributes.getNamedItem(k)?.value;
 
     this.zip = formValues?.zip ?? attr('zip') ?? DEFAULT_ZIP;
@@ -314,7 +318,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
   }
 
   saveFormValues() {
-    safeLocalStorage.setItem<SavedFormValues>(FORM_VALUES_LOCAL_STORAGE_KEY, {
+    safeLocalStorage.setItem(FORM_VALUES_LOCAL_STORAGE_KEY, {
       zip: this.zip,
       ownerStatus: this.ownerStatus,
       householdIncome: this.householdIncome,


### PR DESCRIPTION
## Description

Inspired by HTMLElementTagNameMap, this lets you associate a type with each local storage key you use, and have calls to `getItem` and `setItem` typechecked accordingly.

## Test Plan

It typechecks