### PR TITLE
tomc/footer slot

### DIFF
--- a/src/calculator-footer.ts
+++ b/src/calculator-footer.ts
@@ -4,7 +4,7 @@ import { msg } from '@lit/localize';
 const toNbsp = (s: string) => s.replace(' ', '\u00a0');
 
 export const CALCULATOR_FOOTER = () => html`<slot name="footer">
-  <div class="calculator__footer">
+  <div class="calculator-footer">
     <p>
       ${toNbsp(
         msg('Calculator by', { desc: 'followed by "Rewiring America"' }),

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -178,8 +178,8 @@ export class RewiringAmericaCalculator extends LitElement {
                 error: errorTemplate,
               })}
             `}
-        ${CALCULATOR_FOOTER()}
       </div>
+      ${CALCULATOR_FOOTER()}
     `;
   }
 }

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -565,8 +565,8 @@ export class RewiringAmericaStateCalculator extends LitElement {
           : this._task.status === TaskStatus.ERROR
           ? errorTemplate(this._task.error)
           : nothing}
-        ${CALCULATOR_FOOTER()}
       </div>
+      ${CALCULATOR_FOOTER()}
     `;
   }
 }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -142,9 +142,10 @@ export const baseStyles = css`
     grid-template-rows: min-content;
   }
 
-  .calculator__footer {
+  .calculator-footer {
     min-width: 200px;
     text-align: center;
+    margin-top: 16px;
   }
 
   /* Extra small devices */


### PR DESCRIPTION
Changes:
- adjust footer markup to avoid underlined spaces
- allow overriding footer with a slot
- move calculator footer outside of main .calculator container

For the markup change, it's a minor visual issue, but here it is before:
![Screenshot 2023-11-29 at 9 37 25 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/038a948b-8968-4e8a-a067-cfc1b6a46136)

And after:
![Screenshot 2023-11-29 at 9 37 17 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/e43f8ff7-8306-4281-835e-2a65e50197d4)

It's not the html formatting I'd choose by hand but it seems like otherwise the spaces are significant for rendering.

For the slot, working with @kylehotchkiss we'd like that footer to be customizable for first-party sites. This will need to be a supported part of the API going forward so I'm open to feedback if we want to do it differently. The footer on [the IRA calculator today](https://www.rewiringamerica.org/app/ira-calculator) is:
![Screenshot 2023-11-29 at 9 38 53 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/9e99fd53-5166-44eb-a2b9-b123fbfdf93d)

To achieve this with a slot you'd do this markup:

```html
      <rewiring-america-state-calculator
        api-key="{{ apiKey }}"
        state="RI"
        household-income="80000"
        household-size="1"
        tax-filing="single"
        owner-status="homeowner"
      >
        <div slot="footer">
          Powered by the
          <a href="https://www.rewiringamerica.org/api">Rewiring America API</a>
        </div>
      </rewiring-america-state-calculator>
```

And it's up to the host page to style this:

```css
      div[slot='footer'] {
        text-align: center;
        margin: 48px 0 0 0;
      }

      div[slot='footer'] a {
        color: black;
      }
```

Which looks like this:
![Screenshot 2023-11-29 at 9 45 05 PM](https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/39635/8f2d853b-d9b3-48c1-b0a8-c26a156bb5dc)

The footer used to sit in the DOM inside the `.calculator` element, so it applied the vertical grid spacing to it. I moved it outside that container since that spacing is really only intended to apply to the cards, and I adjusted the class name from as it's no longer contained by the parent `.calculator`.

These are minor cosmetic details so if folks have other suggestions I'm all ears.