### PR TITLE
Fix projects being flattened in submitted event detail

### DIFF
--- a/cypress/e2e/state-calculator-events.cy.ts
+++ b/cypress/e2e/state-calculator-events.cy.ts
@@ -16,6 +16,11 @@ describe('rewiring-america-state-calculator events', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
+      .find('sl-select#projects')
+      .invoke('attr', 'value', 'hvac ev');
+
+    cy.get('rewiring-america-state-calculator')
+      .shadow()
       .find('input#zip')
       .type('02859{enter}')
       .then(() => {
@@ -27,6 +32,7 @@ describe('rewiring-america-state-calculator events', () => {
         expect(event.detail).to.exist;
         expect(event.detail.formData).to.exist;
         expect(event.detail.formData.zip).to.equal('02859');
+        expect(event.detail.formData.projects).to.eql(['ev', 'hvac']);
       });
   });
 

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -321,7 +321,12 @@ export class RewiringAmericaStateCalculator extends LitElement {
         bubbles: true,
         composed: true,
         detail: {
-          formData: Object.fromEntries(formData.entries()),
+          // Preserve projects as an array
+          formData: Object.fromEntries(
+            Array.from(formData.keys()).map(k =>
+              k === 'projects' ? [k, formData.getAll(k)] : [k, formData.get(k)],
+            ),
+          ),
         },
       }),
     );


### PR DESCRIPTION
## Description

`FormData.entries()` gives entries with duplicate keys in the case of multiple-value things like our `projects` array. `Object.fromEntries()` then drops all but the last one. Fix this by explicitly calling `FormData.getAll()` for the `projects` key.

## Test Plan

Cypress test.

Manually, add event listener in rhode-island.html to log the event detail; make sure the projects key is an array, whether there are 0, 1, or more projects selected, and everything else is a string.
