### PR TITLE
Adjust presentation of IRA rebates

### DIFF
--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -350,11 +350,15 @@ const formatIncentiveType = (incentive: Incentive) =>
     ? msg('Performance rebate')
     : msg('Incentive');
 
+/** We're special-casing these to hardcode an availability start date */
+const isIRARebate = (incentive: Incentive) =>
+  incentive.type === 'pos_rebate' && incentive.authority_type === 'federal';
+
 /** TODO get real dates in the data! */
 const startDateTemplate = (incentive: Incentive) =>
-  incentive.type === 'pos_rebate'
+  isIRARebate(incentive)
     ? html`<div class="incentive__chip incentive__chip--warning">
-        ${exclamationPoint()} ${msg('Available early 2024')}
+        ${exclamationPoint()} ${msg('Expected in 2024')}
       </div>`
     : nothing;
 
@@ -411,7 +415,10 @@ const noResultsTemplate = () => html`<div class="card card--null">
 
 const cardCollectionTemplate = (incentives: Incentive[]) =>
   html`<div class="grid-3-2-1 grid-3-2-1--align-start">
-    ${incentives.map(incentiveCardTemplate)}
+    ${incentives
+      // Put IRA rebates after everything else
+      .sort((a, b) => +isIRARebate(a) - +isIRARebate(b))
+      .map(incentiveCardTemplate)}
   </div>`;
 
 const gridTemplate = (

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -123,9 +123,6 @@
 <trans-unit id="sb661e8297dd681e2">
   <source>Incentive</source>
 <target>Incentivo</target></trans-unit>
-<trans-unit id="s8f3dd000e1f39ea9">
-  <source>Available early 2024</source>
-<target>Disponible a principios de 2024</target></trans-unit>
 <trans-unit id="sd99647a59a6f456f">
   <source>Visit site</source>
 <target>Visitar sitio web</target></trans-unit>
@@ -310,6 +307,10 @@
 <trans-unit id="sdc1f8a2139793221">
   <source>Back to calculator</source>
   <target>Volver a la calculadora</target>
+</trans-unit>
+<trans-unit id="s8fd8a424edc336b4">
+  <source>Expected in 2024</source>
+  <target>Esperado en 2024</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
## Description

Per late feedback from RI OER, we're being vaguer about when the IRA
HEEHR/HOMES rebates will be available (now just sometime in 2024, not
early 2024), and sorting them at the end of a set of cards.

## Test Plan

Calculate HVAC incentives, $30k income, 4 people. Make sure the IRA
rebate is the last card in the HVAC section, and the new copy shows up.
