### PR TITLE
Don't show authority logo section if there are no logos

### DIFF
--- a/src/authority-logos.ts
+++ b/src/authority-logos.ts
@@ -46,21 +46,22 @@ export const authorityLogosStyles = css`
  * of the authorities whose incentives are displayed.
  */
 export const authorityLogosTemplate = (response: APIResponse) => {
-  if (Object.keys(response.authorities).length === 0) {
+  const authoritiesWithLogo = Object.values(response.authorities).filter(
+    auth => !!auth.logo,
+  );
+  if (authoritiesWithLogo.length === 0) {
     return nothing;
   }
 
-  const logos = Object.values(response.authorities)
-    .filter(auth => !!auth.logo)
-    .map(
-      auth =>
-        html`<img
-          alt="${auth.name}"
-          src="${auth.logo!.src}"
-          width="${auth.logo!.width}"
-          height="${auth.logo!.height}"
-        />`,
-    );
+  const logos = authoritiesWithLogo.map(
+    auth =>
+      html`<img
+        alt="${auth.name}"
+        src="${auth.logo!.src}"
+        width="${auth.logo!.width}"
+        height="${auth.logo!.height}"
+      />`,
+  );
 
   const title = msg('Incentive data brought to you by', {
     desc: 'followed by authority logos',


### PR DESCRIPTION
## Description

Found this while testing with CT data. Because authorities don't have to have logos, the check has to be for zero authorities _with logos_, not just zero authorities _total_.

## Test Plan

Run against local API host with beta states included (with a change on the API side to return utilities for CT), and enter zip 06033. Make sure no authority logo section shows up, instead of showing up with no logos.
