### PR TITLE
Replace Shoelace blue with RA purple in sl-select highlight

### DIFF
--- a/src/select.ts
+++ b/src/select.ts
@@ -264,6 +264,12 @@ export const selectStyles = css`
 
     --sl-font-sans: var(--ra-embed-font-family);
 
+    /*
+     * This replaces the highlighted-row background color. There's no variable
+     * specifically for that.
+     */
+    --sl-color-primary-600: var(--ra-select-focus-color);
+
     margin-top: 4px;
   }
 


### PR DESCRIPTION
## Description

Shoelace doesn't expose this as a semantic variable (see https://github.com/shoelace-style/shoelace/blob/7891dbef938756aba072b70672a958c49e7ecc50/src/components/option/option.styles.ts#L39) so the solution is to redefine the color it uses.

I think the time when we have to bite the bullet and write our own select component is coming up soon, though I don't think this is the last straw.

## Test Plan

Look at the color in dropdowns.

<img width="451" alt="Screenshot 2023-12-12 at 4 20 05 PM" src="https://github.com/rewiringamerica/embed.rewiringamerica.org/assets/107014/88e98e79-4d17-40f2-8ccd-038e97f5f1c2">