### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/cypress/e2e/state-calculator-events.cy.ts
+++ b/cypress/e2e/state-calculator-events.cy.ts
@@ -45,7 +45,7 @@ describe('rewiring-america-state-calculator events', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('Reset calculator')
+      .contains('Reset')
       .click()
       .then(() => {
         expect(reset).to.be.calledOnce;

--- a/src/state-calculator.html
+++ b/src/state-calculator.html
@@ -33,7 +33,7 @@
         font-weight: 400;
         margin: 32px auto;
         max-width: 1024px;
-        padding: 32px;
+        padding: 24px;
       }
 
       .checkbox-and-label {

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -136,6 +136,13 @@ const formTitleStyles = css`
   .form-title {
     display: flex;
     justify-content: space-between;
+    align-items: baseline;
+  }
+
+  @media screen and (max-width: 640px) {
+    h1 {
+      font-size: 16px;
+    }
   }
 `;
 
@@ -511,7 +518,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
                 class="text-button"
                 @click=${() => this.resetFormValues()}
               >
-                ${msg('Reset calculator')}
+                ${msg('Reset')}
               </button>
             </div>
           </div>

--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -160,13 +160,8 @@ export const stateIncentivesStyles = css`
     }
   }
 
-  .grid-section .card {
-    margin: 0;
-  }
-
   @media only screen and (max-width: 640px) {
     .grid-section {
-      margin: 0 1rem;
       min-width: 200px;
     }
   }
@@ -176,6 +171,7 @@ export const stateIncentivesStyles = css`
 
     color: #111;
     text-align: center;
+    text-wrap: balance;
 
     font-size: 2rem;
     font-weight: 500;
@@ -185,8 +181,6 @@ export const stateIncentivesStyles = css`
 
 export const cardStyles = css`
   .card {
-    margin: 0;
-
     border: var(--ra-embed-card-border);
     border-radius: var(--ra-embed-card-border-radius);
     box-shadow: var(--ra-embed-card-shadow);
@@ -202,7 +196,6 @@ export const cardStyles = css`
   /* Extra small devices */
   @media only screen and (max-width: 640px) {
     .card {
-      margin: 0 1rem;
       min-width: 200px;
     }
   }

--- a/src/utility-selector.ts
+++ b/src/utility-selector.ts
@@ -46,15 +46,10 @@ export const utilitySelectorStyles = css`
   @media only screen and (max-width: 640px) {
     .utility-selector {
       grid-template-columns: 1fr;
-
-      margin-left: 1rem;
-      margin-right: 1rem;
       min-width: 200px;
     }
 
     .utility-selector .card {
-      /* Margin is provided by the outer element */
-      margin: 0;
       max-width: 100%;
     }
   }

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -153,9 +153,6 @@
 <trans-unit id="s57fde82075d7665d">
   <source>Your household info</source>
 <target>Información de su hogar</target></trans-unit>
-<trans-unit id="s64eaba74733e24c0">
-  <source>Reset calculator</source>
-<target>Reiniciar la calculadora</target></trans-unit>
 <trans-unit id="sd4647caeb94889ec">
   <source>Terms</source>
   <note from="lit-localize">as in terms of service</note>
@@ -311,6 +308,10 @@
 <trans-unit id="s8fd8a424edc336b4">
   <source>Expected in 2024</source>
   <target>Esperado en 2024</target>
+</trans-unit>
+<trans-unit id="s255857544a9d5ec0">
+  <source>Reset</source>
+  <target>Reiniciar</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
## Description

- Change "Reset calculator" copy to "Reset" (all layouts).

- Reduce "Your household info" size on small layout.

- Remove side margin from cards on all layouts, and add padding to the
  container on the demo page to compensate. (The consumer site already
  has the side padding.)

## Test Plan

Look at layout at width from 1200px down to 500px. Make sure the
transition at 640px is clean, the header size is reduced, and the side
margins look consistent all the way.
