### PR TITLE
Add Prettier organize-imports plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "arrowParens": "avoid",
-  "printWidth": 80
+  "printWidth": 80,
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "posthtml": "^0.16.6",
     "posthtml-expressions": "^1.11.1",
     "prettier": "^2.8.8",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },

--- a/scripts/parcel-resolver-locales.mjs
+++ b/scripts/parcel-resolver-locales.mjs
@@ -1,7 +1,7 @@
 import { Resolver } from '@parcel/plugin';
 import { exec } from 'child_process';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
 import { promisify } from 'util';
 
 async function allXlfFiles(projectRoot) {

--- a/scripts/strings.ts
+++ b/scripts/strings.ts
@@ -1,7 +1,7 @@
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
-import { stringify } from 'csv-stringify/sync';
-import { parse } from 'csv-parse/sync';
 import { program } from 'commander';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/src/authority-logos.ts
+++ b/src/authority-logos.ts
@@ -1,5 +1,5 @@
-import { css, html, nothing } from 'lit';
 import { msg } from '@lit/localize';
+import { css, html, nothing } from 'lit';
 import { APIResponse } from './api/calculator-types-v1';
 
 export const authorityLogosStyles = css`

--- a/src/calculator-footer.ts
+++ b/src/calculator-footer.ts
@@ -1,5 +1,5 @@
-import { html } from 'lit';
 import { msg } from '@lit/localize';
+import { html } from 'lit';
 
 const toNbsp = (s: string) => s.replace(' ', '\u00a0');
 

--- a/src/calculator-form.ts
+++ b/src/calculator-form.ts
@@ -1,13 +1,13 @@
-import { html, css, unsafeCSS, nothing, TemplateResult } from 'lit';
-import { live } from 'lit/directives/live';
-import { select, multiselect, selectStyles, OptionParam } from './select';
-import { inputStyles } from './styles/input';
-import './currency-input';
-import shoelaceTheme from 'bundle-text:@shoelace-style/shoelace/dist/themes/light.css';
-import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
-import { PROJECTS } from './projects';
-import { tooltipButton } from './tooltip';
 import { msg, str } from '@lit/localize';
+import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
+import shoelaceTheme from 'bundle-text:@shoelace-style/shoelace/dist/themes/light.css';
+import { TemplateResult, css, html, nothing, unsafeCSS } from 'lit';
+import { live } from 'lit/directives/live';
+import './currency-input';
+import { PROJECTS } from './projects';
+import { OptionParam, multiselect, select, selectStyles } from './select';
+import { inputStyles } from './styles/input';
+import { tooltipButton } from './tooltip';
 
 const buttonStyles = css`
   button.primary {

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -1,18 +1,18 @@
+import { Task, initialState } from '@lit-labs/task';
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { Task, initialState } from '@lit-labs/task';
-import { baseStyles, cardStyles, gridStyles } from './styles';
-import { formTemplate, formStyles } from './calculator-form';
-import { detailsStyles, detailsTemplate } from './incentive-details';
-import { summaryStyles, summaryTemplate } from './incentive-summary';
+import { fetchApi } from './api/fetch';
+import { CALCULATOR_FOOTER } from './calculator-footer';
+import { formStyles, formTemplate } from './calculator-form';
 import {
   FilingStatus,
   ICalculatedIncentiveResults,
   OwnerStatus,
 } from './calculator-types';
-import { CALCULATOR_FOOTER } from './calculator-footer';
-import { fetchApi } from './api/fetch';
 import { downIcon } from './icons';
+import { detailsStyles, detailsTemplate } from './incentive-details';
+import { summaryStyles, summaryTemplate } from './incentive-summary';
+import { baseStyles, cardStyles, gridStyles } from './styles';
 
 const loadedTemplate = (
   results: ICalculatedIncentiveResults,

--- a/src/currency-input.ts
+++ b/src/currency-input.ts
@@ -1,8 +1,8 @@
-import { LitElement, html, PropertyValues } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
-import { ref } from 'lit/directives/ref';
 import AutoNumeric from 'autonumeric';
 import 'element-internals-polyfill';
+import { LitElement, PropertyValues, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ref } from 'lit/directives/ref';
 
 @customElement('ra-currency-input')
 export class CurrencyInput extends LitElement {

--- a/src/icon-tab-bar.ts
+++ b/src/icon-tab-bar.ts
@@ -1,5 +1,5 @@
-import { css, html } from 'lit';
 import { msg } from '@lit/localize';
+import { css, html } from 'lit';
 import { PROJECTS, Project, shortLabel } from './projects';
 import { select } from './select';
 

--- a/src/incentive-details.ts
+++ b/src/incentive-details.ts
@@ -1,12 +1,12 @@
 import { css, html } from 'lit';
-import { calculatorTableIcon } from './icons';
-import { tableStyles } from './styles';
 import {
   AmountType,
   ICalculatedIncentiveResults,
   IIncentiveRecord,
   IncentiveType,
 } from './calculator-types';
+import { calculatorTableIcon } from './icons';
+import { tableStyles } from './styles';
 
 const linkButtonStyles = css`
   a.more-info-button,

--- a/src/incentive-summary.ts
+++ b/src/incentive-summary.ts
@@ -1,4 +1,4 @@
-import { html, css, nothing, TemplateResult } from 'lit';
+import { TemplateResult, css, html, nothing } from 'lit';
 import { ICalculatedIncentiveResults } from './calculator-types';
 import { lightningBolt } from './icons';
 

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,5 +1,5 @@
-import { TemplateResult, svg } from 'lit';
 import { msg } from '@lit/localize';
+import { TemplateResult, svg } from 'lit';
 import { ItemType } from './api/calculator-types-v1';
 
 const RA_PURPLE = '#4a00c3';

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,9 +1,9 @@
-import { html, css, unsafeCSS, nothing, HTMLTemplateResult } from 'lit';
-import { ifDefined } from 'lit/directives/if-defined.js';
+import { SlChangeEvent } from '@shoelace-style/shoelace';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import shoelaceTheme from 'bundle-text:@shoelace-style/shoelace/dist/themes/light.css';
-import { SlChangeEvent } from '@shoelace-style/shoelace';
+import { HTMLTemplateResult, css, html, nothing, unsafeCSS } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live';
 
 export interface OptionParam {

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -1,34 +1,34 @@
+import { Task, TaskStatus, initialState } from '@lit-labs/task';
 import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { Task, TaskStatus, initialState } from '@lit-labs/task';
-import { baseStyles } from './styles';
-import { formTemplate, formStyles } from './calculator-form';
-import { FilingStatus, OwnerStatus } from './calculator-types';
-import { CALCULATOR_FOOTER } from './calculator-footer';
 import { fetchApi } from './api/fetch';
+import { CALCULATOR_FOOTER } from './calculator-footer';
+import { formStyles, formTemplate } from './calculator-form';
+import { FilingStatus, OwnerStatus } from './calculator-types';
+import { iconTabBarStyles } from './icon-tab-bar';
+import { Project } from './projects';
 import {
-  stateIncentivesTemplate,
-  stateIncentivesStyles,
   cardStyles,
   separatorStyles,
+  stateIncentivesStyles,
+  stateIncentivesTemplate,
 } from './state-incentive-details';
-import { Project } from './projects';
+import { baseStyles } from './styles';
 import {
   utilitySelectorStyles,
   utilitySelectorTemplate,
 } from './utility-selector';
-import { iconTabBarStyles } from './icon-tab-bar';
 
-import '@shoelace-style/shoelace/dist/components/spinner/spinner';
-import { STATES } from './states';
-import { authorityLogosStyles } from './authority-logos';
-import { APIResponse, APIUtilitiesResponse } from './api/calculator-types-v1';
-import { submitEmailSignup, wasEmailSubmitted } from './email-signup';
-import SlSelect from '@shoelace-style/shoelace/dist/components/select/select';
-import { safeLocalStorage } from './safe-local-storage';
-import scrollIntoView from 'scroll-into-view-if-needed';
 import { configureLocalization, localized, msg, str } from '@lit/localize';
-import { sourceLocale, targetLocales, allLocales } from 'locales:config';
+import SlSelect from '@shoelace-style/shoelace/dist/components/select/select';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner';
+import { allLocales, sourceLocale, targetLocales } from 'locales:config';
+import scrollIntoView from 'scroll-into-view-if-needed';
+import { APIResponse, APIUtilitiesResponse } from './api/calculator-types-v1';
+import { authorityLogosStyles } from './authority-logos';
+import { submitEmailSignup, wasEmailSubmitted } from './email-signup';
+import { safeLocalStorage } from './safe-local-storage';
+import { STATES } from './states';
 
 // See scripts/parcel-resolver-locale.mjs for how this import is resolved.
 const { setLocale } = configureLocalization({

--- a/src/state-incentive-details.ts
+++ b/src/state-incentive-details.ts
@@ -1,12 +1,12 @@
-import { css, html, nothing } from 'lit';
 import { msg, str } from '@lit/localize';
+import { css, html, nothing } from 'lit';
+import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, Incentive, ItemType } from './api/calculator-types-v1';
+import { authorityLogosTemplate } from './authority-logos';
+import { iconTabBarTemplate } from './icon-tab-bar';
 import { exclamationPoint, upRightArrow } from './icons';
 import { PROJECTS, Project, shortLabel } from './projects';
-import { iconTabBarTemplate } from './icon-tab-bar';
-import { authorityLogosTemplate } from './authority-logos';
 import { RewiringAmericaStateCalculator } from './state-calculator';
-import scrollIntoView from 'scroll-into-view-if-needed';
 
 export const stateIncentivesStyles = css`
   /* for now, override these variables just for the state calculator */

--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -1,7 +1,7 @@
-import { HTMLTemplateResult, html } from 'lit';
 import { msg } from '@lit/localize';
-import { questionIcon } from './icons';
 import SlTooltip from '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
+import { HTMLTemplateResult, html } from 'lit';
+import { questionIcon } from './icons';
 
 /** Finds the first SlTooltip ancestor of the given element. */
 function findTooltipAncestor(element: HTMLElement): SlTooltip {

--- a/src/utility-selector.ts
+++ b/src/utility-selector.ts
@@ -1,8 +1,8 @@
-import { css, html } from 'lit';
 import { msg, str } from '@lit/localize';
+import { css, html } from 'lit';
+import { APIUtilityMap } from './api/calculator-types-v1';
 import { select } from './select';
 import { StateInfo } from './states';
-import { APIUtilityMap } from './api/calculator-types-v1';
 import { tooltipButton } from './tooltip';
 
 export const utilitySelectorStyles = css`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3577,6 +3577,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-plugin-organize-imports@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz#77967f69d335e9c8e6e5d224074609309c62845e"
+  integrity sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==
+
 prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"


### PR DESCRIPTION
## Description

We have this in the API code too; it helps keep things neat. Everything in the diff is mechanical except for `package.json` and `.prettierrc`.

## Test Plan

`yarn lint` passes.
