### PR TITLE
only request items we know about

### DIFF
--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -6,7 +6,7 @@ import { CALCULATOR_FOOTER } from './calculator-footer';
 import { formStyles, formTemplate } from './calculator-form';
 import { FilingStatus, OwnerStatus } from './calculator-types';
 import { iconTabBarStyles } from './icon-tab-bar';
-import { Project } from './projects';
+import { PROJECTS, Project } from './projects';
 import {
   cardStyles,
   separatorStyles,
@@ -480,6 +480,11 @@ export class RewiringAmericaStateCalculator extends LitElement {
       if (this.utility) {
         query.set('utility', this.utility);
       }
+      Object.values(PROJECTS).forEach(project => {
+        project.items.forEach(item => {
+          query.append('items', item);
+        });
+      });
 
       return fetchApi<APIResponse>(
         this.apiKey,


### PR DESCRIPTION
## Description

We want to add new items to the API without breaking the calculator. The `?items=` functionality already exists in the API, and the embed code already knows which items we care about, so this just wires the two together.

## Test Plan

Test with each project type in turn, especially HVAC and other projects with multiple item types. Inspect the API request to make sure it's setting `?items=` multiple times.

Note that the `?items=` in the API request will always be the same, no matter which projects are set in the UI, because the multi select just determines which projects are sorted to the top vs placed in the "other" section.