### PR TITLE
tomc/attachinternals

### DIFF
--- a/src/currency-input.ts
+++ b/src/currency-input.ts
@@ -67,12 +67,14 @@ export class CurrencyInput extends LitElement {
     if (input === undefined) {
       this.autonumeric?.detach();
     } else {
-      this.autonumeric = new AutoNumeric(
-        input as HTMLInputElement,
-        this.value,
-        AutoNumeric.getPredefinedOptions().NorthAmerican,
-      );
-      this.updateAutonumericOptions();
+      if (AutoNumeric.getAutoNumericElement(input as HTMLElement) === null) {
+        this.autonumeric = new AutoNumeric(
+          input as HTMLInputElement,
+          this.value,
+          AutoNumeric.getPredefinedOptions().NorthAmerican,
+        );
+        this.updateAutonumericOptions();
+      }
     }
   }
 


### PR DESCRIPTION
## Description

In Cypress, mousing over some of the assertions does some clever DOM bookkeeping to rewind state, and this resulted in some warnings in the console related to how we're using `attachInternals` and `AutoNumeric` for the currency input. For the former, it appears to be intended to only do `attachInternals` in the constructor. For the latter, `AutoNumeric` provides a helper to check if an input is already tracked in its internal state. This PR does both.

- do attachInternals in constructor so it only happens once
- only wire up AutoNumeric if we didn't already


## Test Plan

I think our test coverage is sufficient here, but worth clicking through both the old and new calculator in the preview build just to be sure.

https://caniuse.com/mdn-api_htmlelement_attachinternals reminds me that it was last year's vintage of Safari that needed an attachInternals polyfill. Not sure there's any practical way to test with those...