### PR TITLE
Update to the way React elements are rendered

### DIFF
--- a/src/authority-logos.tsx
+++ b/src/authority-logos.tsx
@@ -48,15 +48,16 @@ type Props = { response: APIResponse };
  * of the authorities whose incentives are displayed.
  */
 export const AuthorityLogos = ({ response }: Props) => {
-  const authoritiesWithLogo = Object.values(response.authorities).filter(
-    auth => !!auth.logo,
+  const authoritiesWithLogo = Object.entries(response.authorities).filter(
+    ([, auth]) => !!auth.logo,
   );
   if (authoritiesWithLogo.length === 0) {
     return <></>;
   }
 
-  const logos = authoritiesWithLogo.map(auth => (
+  const logos = authoritiesWithLogo.map(([id, auth]) => (
     <img
+      key={id}
       alt={auth.name}
       src={auth.logo!.src}
       width={auth.logo!.width}

--- a/src/react-roots.tsx
+++ b/src/react-roots.tsx
@@ -1,0 +1,49 @@
+import { StrictMode } from 'react';
+import { Root, createRoot } from 'react-dom/client';
+
+/**
+ * During the React transition, we render various sub-parts of the component
+ * using React; this is where that's actually carried out.
+ *
+ * During render(), Lit elements add empty divs to the DOM, for React elements
+ * to be rendered into later. Pass in a mapping of those empty divs' IDs
+ * to the React elements to be rendered into them, as reactElements, from the
+ * Lit element's updated() function.
+ *
+ * The React roots are cached in reactRoots so they can be reused if Lit has
+ * preserved the underlying DOM node across render cycles.
+ */
+export function renderReactElements(
+  shadowRoot: ShadowRoot,
+  reactElements: Map<string, React.ReactElement>,
+  reactRoots: Map<string, { reactRoot: Root; domNode: HTMLElement }>,
+) {
+  reactElements.forEach((element, rootId) => {
+    let root: Root | null = null;
+
+    // If we already have a React root for this element, and the DOM node is
+    // still part of the document, reuse it.
+    if (reactRoots.has(rootId)) {
+      const { reactRoot, domNode } = reactRoots.get(rootId)!;
+      if (domNode.isConnected) {
+        root = reactRoot;
+      } else {
+        reactRoots.delete(rootId);
+      }
+    }
+
+    // If there was no React root for this element, or the DOM node it was
+    // created on is not part of the document, create a new one.
+    if (!root) {
+      const domNode = shadowRoot.getElementById(rootId);
+      if (!domNode) {
+        return;
+      }
+      root = createRoot(domNode);
+      reactRoots.set(rootId, { reactRoot: root, domNode });
+    }
+
+    root.render(<StrictMode>{element}</StrictMode>);
+  });
+  reactElements.clear();
+}

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -1,6 +1,5 @@
 import { msg, str } from '@lit/localize';
 import { css, html, nothing } from 'lit';
-import { createRoot } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, Incentive, ItemType } from './api/calculator-types-v1';
 import { AuthorityLogos } from './authority-logos';
@@ -532,7 +531,7 @@ const gridTemplate = (
  * currently selected.
  */
 export const stateIncentivesTemplate = (
-  registerUpdateCallback: (callback: (root: ShadowRoot) => void) => void,
+  registerReactElement: (rootId: string, element: React.ReactElement) => void,
   response: APIResponse,
   selectedProjects: Project[],
   onOtherTabSelected: (newOtherSelection: Project) => void,
@@ -578,10 +577,9 @@ export const stateIncentivesTemplate = (
   const selectedOtherIncentives = incentivesByProject[otherTab] ?? [];
 
   // Render any React components
-  registerUpdateCallback((root: ShadowRoot) =>
-    createRoot(root.getElementById('authority-logos')!).render(
-      <AuthorityLogos response={response} />,
-    ),
+  registerReactElement(
+    'authority-logos',
+    <AuthorityLogos response={response} />,
   );
 
   return html`${gridTemplate(


### PR DESCRIPTION
## Description

Working on more sophisticated components revealed a problem with the
previous approach: calling `createRoot` repeatedly with the same DOM
node.

To prevent this, we now store the React `Root` and corresponding DOM
node for each React element that gets rendered. During the Lit update
cycle, it reuses the existing stored React root if it's present and
the DOM node is still in the document.

The logic is factored out because the old embed will need to share it soon.

Also, a drive-by fix to AuthorityLogos: the img elements needed keys.

## Test Plan

Use the state calculator, in particular alternating between
calculating for a RI zip code and then a MA zip code (the important
thing being that one state will show AuthorityLogos and one
won't). Make sure the authority logos show up, or don't show up, as
appropriate.

Make sure the console is free of any React error messages.
