### PR TITLE
Tailwindize cards in new calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@lit/localize": "^0.12.1",
     "@shoelace-style/shoelace": "^2.12.0",
     "autonumeric": "^4.8.1",
+    "clsx": "^2.1.0",
     "lit": "^2.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/card.tsx
+++ b/src/card.tsx
@@ -1,0 +1,39 @@
+import { FC, PropsWithChildren } from 'react';
+
+import clsx from 'clsx';
+
+/**
+ * Renders a padded card with white background and drop shadow. "isFlat" uses
+ * a yellow background and no shadow instead. Children are placed in a
+ * 1-column grid.
+ */
+export const Card: FC<PropsWithChildren<{ id?: string; isFlat?: boolean }>> = ({
+  id,
+  isFlat,
+  children,
+}) => (
+  <div
+    id={id}
+    className={clsx(
+      'rounded-xl',
+      'overflow-clip',
+      'min-w-52',
+      { shadow: !isFlat },
+      isFlat ? 'bg-yellow-200' : 'bg-white',
+    )}
+  >
+    <div
+      className={clsx(
+        'grid',
+        'grid-cols-1',
+        'gap-4',
+        isFlat ? ['px-4', 'py-8'] : ['p-4', 'sm:p-6'],
+        { 'mx-auto': isFlat },
+        { 'text-center': isFlat },
+        { 'max-w-78': isFlat },
+      )}
+    >
+      {children}
+    </div>
+  </div>
+);

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -11,6 +11,7 @@ import { fetchApi } from './api/fetch';
 import { CalculatorFooter } from './calculator-footer';
 import { CalculatorForm, FormValues, formStyles } from './calculator-form';
 import { FilingStatus, OwnerStatus } from './calculator-types';
+import { Card } from './card';
 import { submitEmailSignup, wasEmailSubmitted } from './email-signup';
 import { allLocales, sourceLocale, targetLocales } from './locales/locales';
 import * as spanishLocale from './locales/strings/es';
@@ -20,7 +21,6 @@ import { safeLocalStorage } from './safe-local-storage';
 import { Separator } from './separator';
 import {
   StateIncentives,
-  cardStyles,
   stateIncentivesStyles,
 } from './state-incentive-details';
 import { baseStyles } from './styles';
@@ -37,16 +37,16 @@ const { setLocale } = configureLocalization({
 });
 
 const loadingTemplate = () => (
-  <div className="card card-content">
+  <Card>
     <SlSpinner className="mx-auto text-3xl" />
-  </div>
+  </Card>
 );
 const errorTemplate = (error: unknown) => (
-  <div className="card card-content" id="error-message">
+  <Card id="error-message">
     {typeof error === 'object' && error && 'message' in error && error.message
       ? (error.message as string)
       : msg('Error loading incentives.')}
-  </div>
+  </Card>
 );
 /**
  * Waits for the next event loop (to allow the DOM to update following an
@@ -98,7 +98,6 @@ export class RewiringAmericaStateCalculator extends LitElement {
   static override styles = [
     unsafeCSS(tailwindStyles),
     baseStyles,
-    cardStyles,
     ...formStyles,
     stateIncentivesStyles,
   ];
@@ -349,7 +348,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
   override render() {
     const calculator = (
       <>
-        <div className="card card-content">
+        <Card>
           <div className="flex justify-between items-baseline">
             <h1 className="text-base sm:text-xl">
               {msg('Your household info')}
@@ -401,7 +400,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
             onSubmit={values => this.submit(values)}
             gridClass="grid grid-cols-1 sm:grid-cols-2 gap-4 items-start"
           />
-        </div>
+        </Card>
         {this._task.render({
           initial: () => null,
           pending: loadingTemplate,

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -4,6 +4,7 @@ import { FC, Key, PropsWithChildren, useState } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, Incentive, ItemType } from './api/calculator-types-v1';
 import { AuthorityLogos } from './authority-logos';
+import { Card } from './card';
 import { wasEmailSubmitted } from './email-signup';
 import { IconTabBar } from './icon-tab-bar';
 import { ExclamationPoint, UpRightArrow } from './icons';
@@ -13,12 +14,6 @@ import { Separator } from './separator';
 export const stateIncentivesStyles = css`
   /* for now, override these variables just for the state calculator */
   :host {
-    /* cards */
-    --ra-embed-card-border: none;
-    --ra-embed-card-shadow: 0px 0px 15px 0px rgba(0, 0, 0, 0.08);
-    --ra-embed-card-border-radius: 0.75rem;
-    --ra-embed-card-shadow--null: none;
-    --ra-embed-card-background--null: var(--rewiring-light-yellow);
     /* labels */
     --ra-form-label-font-size: 11px;
     --ra-form-label-line-height: 20px;
@@ -43,49 +38,6 @@ export const stateIncentivesStyles = css`
     --ra-input-focus-color: var(--rewiring-purple);
     --ra-input-margin: 0;
     --ra-input-padding: 0.5rem 0.75rem;
-  }
-`;
-
-export const cardStyles = css`
-  .card {
-    border: var(--ra-embed-card-border);
-    border-radius: var(--ra-embed-card-border-radius);
-    box-shadow: var(--ra-embed-card-shadow);
-    background-color: var(--ra-embed-card-background);
-    overflow: clip;
-  }
-
-  .card--null {
-    background-color: var(--ra-embed-card-background--null);
-    box-shadow: var(--ra-embed-card-shadow--null);
-  }
-
-  /* Extra small devices */
-  @media only screen and (max-width: 640px) {
-    .card {
-      min-width: 200px;
-    }
-  }
-
-  .card-content {
-    padding: 1.5rem;
-    display: grid;
-    grid-template-rows: min-content;
-    gap: 1rem;
-  }
-
-  /* Extra small devices */
-  @media only screen and (max-width: 640px) {
-    .card-content {
-      padding: 1rem;
-    }
-  }
-
-  .card-content--null {
-    padding: 2rem 1rem;
-    text-align: center;
-    max-width: 312px;
-    margin: 0 auto;
   }
 `;
 
@@ -272,28 +224,26 @@ const LinkButton: FC<PropsWithChildren<{ href: string }>> = ({
 };
 
 const renderIncentiveCard = (key: Key, incentive: Incentive) => (
-  <div className="card" key={key}>
-    <div className="card-content">
-      <div className="flex flex-col gap-4 h-full">
-        <Chip>{formatIncentiveType(incentive)}</Chip>
-        <div className="text-gray-700 text-xl leading-normal">
-          {formatTitle(incentive)}
-        </div>
-        <div className="text-gray-700 font-medium leading-tight">
-          {incentive.program}
-        </div>
-        <Separator hideOnSmall={true} />
-        <div className="text-grey-400 leading-normal">
-          {incentive.short_description}
-        </div>
-        {renderStartDate(incentive)}
-        <LinkButton href={incentive.program_url ?? incentive.item.url}>
-          {incentive.program_url ? msg('Visit site') : msg('Learn more')}
-          {incentive.program_url ? <UpRightArrow w={20} h={20} /> : null}
-        </LinkButton>
+  <Card key={key}>
+    <div className="flex flex-col gap-4 h-full">
+      <Chip>{formatIncentiveType(incentive)}</Chip>
+      <div className="text-gray-700 text-xl leading-normal">
+        {formatTitle(incentive)}
       </div>
+      <div className="text-gray-700 font-medium leading-tight">
+        {incentive.program}
+      </div>
+      <Separator hideOnSmall={true} />
+      <div className="text-grey-400 leading-normal">
+        {incentive.short_description}
+      </div>
+      {renderStartDate(incentive)}
+      <LinkButton href={incentive.program_url ?? incentive.item.url}>
+        {incentive.program_url ? msg('Visit site') : msg('Learn more')}
+        {incentive.program_url ? <UpRightArrow w={20} h={20} /> : null}
+      </LinkButton>
     </div>
-  </div>
+  </Card>
 );
 function scrollToForm(event: React.MouseEvent) {
   const calculator = (
@@ -366,22 +316,20 @@ const renderNoResults = (emailSubmitter: ((email: string) => void) | null) => {
     );
 
   return (
-    <div className="card card--null">
-      <div className="card-content card-content--null">
-        <h1 className="text-grey-700 text-xl font-normal">
-          {msg('No incentives available for this project')}
-        </h1>
-        <p>
-          {msg(
-            'This could be because there are no incentives in your area, or you don’t financially qualify for any incentives.',
-          )}
-        </p>
-        <button className="text-button" onClick={scrollToForm}>
-          {msg('Back to calculator')}
-        </button>
-        {emailForm}
-      </div>
-    </div>
+    <Card isFlat={true}>
+      <h1 className="text-grey-700 text-xl font-normal">
+        {msg('No incentives available for this project')}
+      </h1>
+      <p>
+        {msg(
+          'This could be because there are no incentives in your area, or you don’t financially qualify for any incentives.',
+        )}
+      </p>
+      <button className="text-button" onClick={scrollToForm}>
+        {msg('Back to calculator')}
+      </button>
+      {emailForm}
+    </Card>
   );
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,9 @@ module.exports = {
       ]),
     ),
     extend: {
+      boxShadow: {
+        DEFAULT: '0px 0px 15px 0px rgba(0, 0, 0, 0.08)',
+      },
       fontSize: {
         xsm: '0.6875rem', // 11px
         sm: '0.8125rem', // 13px
@@ -22,6 +25,9 @@ module.exports = {
         '2xl': '1.75rem', // 28px
         '3xl': '2rem', // 32px
         '4xl': '2.25rem', // 36px
+      },
+      maxWidth: {
+        78: '19.5rem',
       },
       minWidth: {
         24: '6rem', // 96px

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,11 @@ clone@^2.1.1:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"


### PR DESCRIPTION
## Description

I chose not to use the CSS variables to define the look of this
component, instead just hardcoding the values that are actually in
effect. Since the state calculator was designed from scratch, I think
it makes more sense to design a customization regime from scratch as
well, rather than having ad-hoc customization points left over from
the old calculator. I'm willing to be convinced otherwise on that
choice, though.

## Test Plan

Flip back and forth between this and prod, making sure cards are
pixel-identical. Use a high income + "cooking" only to see the "flat"
card (empty results state).
