### PR TITLE
Split form code into old and new calculator versions; Tailwind the latter

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -46,7 +46,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .find('button.primary')
+      .find('button#calculate')
       .click();
 
     cy.get('rewiring-america-state-calculator')

--- a/src/buttons.tsx
+++ b/src/buttons.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+import { FC, PropsWithChildren } from 'react';
+
+/** A button that looks like a real button; white text on purple. */
+export const PrimaryButton: FC<
+  PropsWithChildren<{ id?: string; onClick?: (e: React.MouseEvent) => void }>
+> = ({ id, children, onClick }) => (
+  <button
+    id={id}
+    className={clsx(
+      'w-full',
+      'text-base',
+      'leading-7',
+      'p-2',
+      'bg-purple-500',
+      'border-purple-500',
+      'border',
+      'text-white',
+      'rounded',
+      'font-semibold',
+      'hover:bg-[--rewiring-purple-darker]',
+      'focus:bg-[--rewiring-purple-darker]',
+      'outline-0',
+    )}
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+
+/** A button that looks like a link; no border or background. */
+export const TextButton: FC<
+  PropsWithChildren<{ onClick?: (e: React.MouseEvent) => void }>
+> = ({ children, onClick }) => (
+  <button
+    className="text-purple-500 text-base font-medium leading-tight hover:underline"
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);

--- a/src/calculator-form.tsx
+++ b/src/calculator-form.tsx
@@ -1,12 +1,10 @@
 import { msg, str } from '@lit/localize';
 import { css } from 'lit';
-import { FC, useEffect, useState } from 'react';
-import { APIUtilitiesResponse } from './api/calculator-types-v1';
+import { FC, useState } from 'react';
 import { FilingStatus, OwnerStatus } from './calculator-types';
 import { CurrencyInput } from './currency-input';
-import { PROJECTS, Project } from './projects';
-import { MultiSelect, OptionParam, Select } from './select';
-import { STATES } from './states';
+import { DownIcon } from './icons';
+import { OptionParam, Select } from './select';
 import { TooltipButton } from './tooltip';
 
 export const buttonStyles = css`
@@ -29,51 +27,6 @@ export const buttonStyles = css`
   button.primary:hover,
   button.primary:focus {
     background-color: var(--ra-embed-primary-button-background-hover-color);
-  }
-
-  button.text-button {
-    appearance: none;
-    padding: 0;
-    margin: 0;
-    outline: 0;
-    text-decoration: none;
-
-    border: none;
-    border-radius: 0;
-    background-color: transparent;
-    cursor: pointer;
-
-    color: var(--rewiring-purple);
-    font-family: inherit;
-    font-size: 1rem;
-    font-weight: 500;
-    line-height: 125%;
-  }
-
-  button.text-button:hover {
-    text-decoration: underline;
-  }
-
-  .grid-right-column {
-    grid-column: -2 / -1;
-  }
-
-  /* To line the button up with the email field when it's present */
-  .button-spacer {
-    height: 36px;
-  }
-
-  @media only screen and (max-width: 640px) {
-    .button-spacer {
-      height: 0;
-    }
-  }
-
-  .help-text {
-    color: #757575;
-    font-size: 0.6875rem;
-    line-height: 150%;
-    margin: 0.25rem 0.75rem 0 0.75rem;
   }
 `;
 
@@ -113,150 +66,19 @@ const label = (labelText: string, tooltipText: string, tooltipSize: number) => {
   );
 };
 
-const renderUtilityField = (
-  utility: string,
-  setUtility: (newValue: string) => void,
-  utilitiesFetch: FetchState,
-  tooltipSize: number,
-) => {
-  const labelSlot = label(
-    msg('Electric Utility', { desc: 'as in utility company' }),
-    msg('Choose the company you pay your electric bill to.'),
-    tooltipSize,
-  );
-  const options: OptionParam<string>[] =
-    utilitiesFetch.state === 'complete'
-      ? Object.entries(utilitiesFetch.response.utilities).map(([id, info]) => ({
-          value: id,
-          label: info.name,
-        }))
-      : [];
-
-  const enterZipToSelect = msg('Enter your ZIP code to select a utility.');
-  const helpText =
-    utilitiesFetch.state === 'init' || utilitiesFetch.state === 'loading'
-      ? enterZipToSelect
-      : utilitiesFetch.state === 'complete'
-      ? Object.keys(utilitiesFetch.response.utilities).length
-        ? enterZipToSelect
-        : msg('We don’t have utility data for your area yet.')
-      : utilitiesFetch.message;
-
-  return (
-    <Select
-      id="utility"
-      labelSlot={labelSlot}
-      placeholder={msg('Select utility')}
-      disabled={options.length === 0}
-      options={options}
-      currentValue={utility}
-      onChange={setUtility}
-      helpText={helpText}
-      loading={utilitiesFetch.state === 'loading'}
-    />
-  );
-};
-
-const renderProjectsField = (
-  projects: Project[],
-  setProjects: (newProjects: Project[]) => void,
-  tooltipSize: number,
-) => (
-  <MultiSelect
-    id="projects"
-    labelSlot={label(
-      msg('Projects you’re most interested in'),
-      msg('Select the projects you’re most interested in.'),
-      tooltipSize,
-    )}
-    options={Object.entries(PROJECTS)
-      .map(([value, data]) => ({
-        value: value as Project,
-        label: data.label(),
-        iconURL: data.iconURL,
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label))}
-    currentValues={projects}
-    onChange={setProjects}
-    placeholder={msg('None selected')}
-    maxOptionsVisible={1}
-    placement={'top'}
-  />
-);
-
-const renderEmailField = (email: string, setEmail: (e: string) => void) => (
-  <div>
-    <label htmlFor="email">
-      <div className="select-label">{msg('Email address (optional)')}</div>
-    </label>
-    <input
-      tabIndex={0}
-      id="email"
-      placeholder={msg('you@example.com', {
-        desc: 'example email address',
-      })}
-      name="email"
-      value={email}
-      onChange={event => setEmail(event.currentTarget.value)}
-      type="email"
-      autoComplete="email"
-    />
-    <div className="help-text">
-      {msg(
-        'Get updates on incentives, rebates, and more from Rewiring America.',
-      )}
-    </div>
-  </div>
-);
-
-type FetchState =
-  | {
-      state: 'init';
-    }
-  | {
-      state: 'loading';
-    }
-  | {
-      state: 'complete';
-      response: APIUtilitiesResponse;
-    }
-  | {
-      state: 'error';
-      message: string;
-    };
-
 export type FormValues = {
   zip: string;
   ownerStatus: OwnerStatus;
   householdIncome: string;
   householdSize: string;
   taxFiling: FilingStatus;
-  utility?: string;
-  projects?: Project[];
-  email?: string;
 };
 
 export const CalculatorForm: FC<{
   initialValues: FormValues;
-  showEmailField: boolean;
-  showProjectField: boolean;
-  utilityFetcher?: (zip: string) => Promise<APIUtilitiesResponse>;
-  stateId?: string;
   tooltipSize: number;
-  calculateButtonContent: React.ReactElement | string;
   onSubmit: (formValues: FormValues) => void;
-  gridClass?: string;
-}> = ({
-  initialValues,
-  showEmailField,
-  showProjectField,
-  utilityFetcher,
-  stateId,
-  tooltipSize,
-  calculateButtonContent,
-  onSubmit,
-  gridClass = 'grid-3-2',
-}) => {
+}> = ({ initialValues, tooltipSize, onSubmit }) => {
   const [zip, setZip] = useState(initialValues.zip);
   const [ownerStatus, setOwnerStatus] = useState(initialValues.ownerStatus);
   const [householdIncome, setHouseholdIncome] = useState(
@@ -266,52 +88,6 @@ export const CalculatorForm: FC<{
     initialValues.householdSize,
   );
   const [taxFiling, setTaxFiling] = useState(initialValues.taxFiling);
-  const [utility, setUtility] = useState(initialValues.utility ?? '');
-  const [projects, setProjects] = useState(initialValues.projects ?? []);
-  const [email, setEmail] = useState(initialValues.email ?? '');
-
-  const [utilitiesFetchState, setUtilitiesFetchState] = useState<FetchState>({
-    state: 'init',
-  });
-
-  useEffect(() => {
-    if (!utilityFetcher || !zip.match(/^\d{5}$/)) {
-      return;
-    }
-
-    setUtilitiesFetchState({ state: 'loading' });
-    utilityFetcher(zip)
-      .then(response => {
-        // If our "state" attribute is set, enforce that the entered location is
-        // in that state.
-        if (stateId && stateId !== response.location.state) {
-          setUtility('');
-
-          // Throw to put the task into the ERROR state for rendering.
-          const stateCodeOrName = STATES[stateId]?.name() ?? stateId;
-          throw new Error(
-            msg(str`That ZIP code is not in ${stateCodeOrName}.`),
-          );
-        }
-
-        setUtilitiesFetchState({ state: 'complete', response });
-
-        // Preserve the previous utility selection if it's still available.
-        // Select the first option in the list otherwise.
-        const keys = Object.keys(response.utilities);
-        if (keys.length > 0) {
-          if (!keys.includes(utility)) {
-            setUtility(keys[0]);
-          }
-        } else {
-          setUtility('');
-        }
-      })
-      .catch(exc =>
-        setUtilitiesFetchState({ state: 'error', message: exc.message }),
-      );
-  }, [stateId, zip]);
-
   return (
     <form
       onSubmit={e => {
@@ -322,16 +98,10 @@ export const CalculatorForm: FC<{
           householdIncome,
           householdSize,
           taxFiling,
-          utility,
-          projects,
-          email,
         });
       }}
     >
-      <div className={gridClass}>
-        {showProjectField
-          ? renderProjectsField(projects, setProjects, tooltipSize)
-          : null}
+      <div className="grid-3-2">
         <Select
           id="owner_status"
           labelSlot={label(
@@ -370,14 +140,6 @@ export const CalculatorForm: FC<{
             onChange={event => setZip(event.currentTarget.value)}
           />
         </div>
-        {utilityFetcher
-          ? renderUtilityField(
-              utility,
-              setUtility,
-              utilitiesFetchState,
-              tooltipSize,
-            )
-          : null}
         <div>
           <label htmlFor="household_income">
             {label(
@@ -424,11 +186,9 @@ export const CalculatorForm: FC<{
           currentValue={householdSize}
           onChange={setHouseholdSize}
         />
-        {showEmailField ? renderEmailField(email, setEmail) : null}
-        <div className="grid-right-column">
-          <div className="button-spacer"></div>
+        <div>
           <button className="primary" type="submit">
-            {calculateButtonContent}
+            Calculate! <DownIcon w={18} h={18} />
           </button>
         </div>
       </div>

--- a/src/calculator.tsx
+++ b/src/calculator.tsx
@@ -11,7 +11,6 @@ import {
   ICalculatedIncentiveResults,
   OwnerStatus,
 } from './calculator-types';
-import { DownIcon } from './icons';
 import { IncentiveDetails, detailsStyles } from './incentive-details';
 import { IncentiveSummary, summaryStyles } from './incentive-summary';
 import { renderReactElements } from './react-roots';
@@ -173,13 +172,6 @@ export class RewiringAmericaCalculator extends LitElement {
                 householdSize: this.householdSize,
               }}
               tooltipSize={18}
-              showEmailField={false}
-              showProjectField={false}
-              calculateButtonContent={
-                <>
-                  Calculate! <DownIcon w={18} h={18} />
-                </>
-              }
               onSubmit={e => this.submit(e)}
             />
           )}

--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -1,0 +1,368 @@
+import { msg, str } from '@lit/localize';
+import { FC, useEffect, useState } from 'react';
+import { APIUtilitiesResponse } from './api/calculator-types-v1';
+import { PrimaryButton } from './buttons';
+import { FilingStatus, OwnerStatus } from './calculator-types';
+import { CurrencyInput } from './currency-input';
+import { PROJECTS, Project } from './projects';
+import { MultiSelect, OptionParam, Select } from './select';
+import { STATES } from './states';
+import { TooltipButton } from './tooltip';
+
+const OWNER_STATUS_OPTIONS: () => OptionParam<OwnerStatus>[] = () => [
+  { value: 'homeowner', label: msg('Homeowner') },
+  { value: 'renter', label: msg('Renter') },
+];
+
+const TAX_FILING_OPTIONS: () => OptionParam<FilingStatus>[] = () => [
+  { value: 'single', label: msg('Single') },
+  { value: 'joint', label: msg('Married filing jointly') },
+  {
+    value: 'married_filing_separately',
+    label: msg('Married filing separately'),
+  },
+  { value: 'hoh', label: msg('Head of household') },
+];
+
+const HH_SIZES = ['1', '2', '3', '4', '5', '6', '7', '8'] as const;
+const HOUSEHOLD_SIZE_OPTIONS: () => OptionParam<
+  (typeof HH_SIZES)[number]
+>[] = () =>
+  HH_SIZES.map(count => ({
+    label:
+      count === '1'
+        ? msg('1 person')
+        : msg(str`${count} people`, { desc: 'count is greater than 1' }),
+    value: count,
+  }));
+
+const label = (
+  labelText: string,
+  tooltipText?: string,
+  tooltipSize?: number,
+) => {
+  return (
+    <div
+      className="flex gap-1 my-2 text-xsm leading-5 font-bold uppercase tracking-[0.55px]"
+      slot="label"
+    >
+      {labelText}
+      {tooltipSize && tooltipText ? (
+        <TooltipButton text={tooltipText} iconSize={tooltipSize} />
+      ) : null}
+    </div>
+  );
+};
+
+const renderUtilityField = (
+  utility: string,
+  setUtility: (newValue: string) => void,
+  utilitiesFetch: FetchState,
+  tooltipSize: number,
+) => {
+  const labelSlot = label(
+    msg('Electric Utility', { desc: 'as in utility company' }),
+    msg('Choose the company you pay your electric bill to.'),
+    tooltipSize,
+  );
+  const options: OptionParam<string>[] =
+    utilitiesFetch.state === 'complete'
+      ? Object.entries(utilitiesFetch.response.utilities).map(([id, info]) => ({
+          value: id,
+          label: info.name,
+        }))
+      : [];
+
+  const enterZipToSelect = msg('Enter your ZIP code to select a utility.');
+  const helpText =
+    utilitiesFetch.state === 'init' || utilitiesFetch.state === 'loading'
+      ? enterZipToSelect
+      : utilitiesFetch.state === 'complete'
+      ? Object.keys(utilitiesFetch.response.utilities).length
+        ? enterZipToSelect
+        : msg('We don’t have utility data for your area yet.')
+      : utilitiesFetch.message;
+
+  return (
+    <Select
+      id="utility"
+      labelSlot={labelSlot}
+      placeholder={msg('Select utility')}
+      disabled={options.length === 0}
+      options={options}
+      currentValue={utility}
+      onChange={setUtility}
+      helpText={helpText}
+      loading={utilitiesFetch.state === 'loading'}
+    />
+  );
+};
+
+const renderProjectsField = (
+  projects: Project[],
+  setProjects: (newProjects: Project[]) => void,
+  tooltipSize: number,
+) => (
+  <MultiSelect
+    id="projects"
+    labelSlot={label(
+      msg('Projects you’re most interested in'),
+      msg('Select the projects you’re most interested in.'),
+      tooltipSize,
+    )}
+    options={Object.entries(PROJECTS)
+      .map(([value, data]) => ({
+        value: value as Project,
+        label: data.label(),
+        iconURL: data.iconURL,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))}
+    currentValues={projects}
+    onChange={setProjects}
+    placeholder={msg('None selected')}
+    maxOptionsVisible={1}
+    placement={'top'}
+  />
+);
+
+const renderEmailField = (email: string, setEmail: (e: string) => void) => (
+  <div>
+    <label htmlFor="email">{label(msg('Email address (optional)'))}</label>
+    <input
+      tabIndex={0}
+      id="email"
+      placeholder={msg('you@example.com', {
+        desc: 'example email address',
+      })}
+      name="email"
+      value={email}
+      onChange={event => setEmail(event.currentTarget.value)}
+      type="email"
+      autoComplete="email"
+    />
+    <div className="mt-1 mx-3 text-grey-300 text-xsm leading-normal">
+      {msg(
+        'Get updates on incentives, rebates, and more from Rewiring America.',
+      )}
+    </div>
+  </div>
+);
+
+type FetchState =
+  | {
+      state: 'init';
+    }
+  | {
+      state: 'loading';
+    }
+  | {
+      state: 'complete';
+      response: APIUtilitiesResponse;
+    }
+  | {
+      state: 'error';
+      message: string;
+    };
+
+export type FormValues = {
+  zip: string;
+  ownerStatus: OwnerStatus;
+  householdIncome: string;
+  householdSize: string;
+  taxFiling: FilingStatus;
+  utility?: string;
+  projects?: Project[];
+  email?: string;
+};
+
+export const CalculatorForm: FC<{
+  initialValues: FormValues;
+  showEmailField: boolean;
+  showProjectField: boolean;
+  utilityFetcher: (zip: string) => Promise<APIUtilitiesResponse>;
+  stateId?: string;
+  tooltipSize: number;
+  onSubmit: (formValues: FormValues) => void;
+}> = ({
+  initialValues,
+  showEmailField,
+  showProjectField,
+  utilityFetcher,
+  stateId,
+  tooltipSize,
+  onSubmit,
+}) => {
+  const [zip, setZip] = useState(initialValues.zip);
+  const [ownerStatus, setOwnerStatus] = useState(initialValues.ownerStatus);
+  const [householdIncome, setHouseholdIncome] = useState(
+    initialValues.householdIncome,
+  );
+  const [householdSize, setHouseholdSize] = useState(
+    initialValues.householdSize,
+  );
+  const [taxFiling, setTaxFiling] = useState(initialValues.taxFiling);
+  const [utility, setUtility] = useState(initialValues.utility ?? '');
+  const [projects, setProjects] = useState(initialValues.projects ?? []);
+  const [email, setEmail] = useState(initialValues.email ?? '');
+
+  const [utilitiesFetchState, setUtilitiesFetchState] = useState<FetchState>({
+    state: 'init',
+  });
+
+  useEffect(() => {
+    if (!utilityFetcher || !zip.match(/^\d{5}$/)) {
+      return;
+    }
+
+    setUtilitiesFetchState({ state: 'loading' });
+    utilityFetcher(zip)
+      .then(response => {
+        // If our "state" attribute is set, enforce that the entered location is
+        // in that state.
+        if (stateId && stateId !== response.location.state) {
+          setUtility('');
+
+          // Throw to put the task into the ERROR state for rendering.
+          const stateCodeOrName = STATES[stateId]?.name() ?? stateId;
+          throw new Error(
+            msg(str`That ZIP code is not in ${stateCodeOrName}.`),
+          );
+        }
+
+        setUtilitiesFetchState({ state: 'complete', response });
+
+        // Preserve the previous utility selection if it's still available.
+        // Select the first option in the list otherwise.
+        const keys = Object.keys(response.utilities);
+        if (keys.length > 0) {
+          if (!keys.includes(utility)) {
+            setUtility(keys[0]);
+          }
+        } else {
+          setUtility('');
+        }
+      })
+      .catch(exc =>
+        setUtilitiesFetchState({ state: 'error', message: exc.message }),
+      );
+  }, [stateId, zip]);
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        onSubmit({
+          zip,
+          ownerStatus,
+          householdIncome,
+          householdSize,
+          taxFiling,
+          utility,
+          projects,
+          email,
+        });
+      }}
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-start">
+        {showProjectField
+          ? renderProjectsField(projects, setProjects, tooltipSize)
+          : null}
+        <Select
+          id="owner_status"
+          labelSlot={label(
+            msg('Rent or own', { desc: 'form field label' }),
+            msg('Homeowners and renters qualify for different incentives.'),
+            tooltipSize,
+          )}
+          options={OWNER_STATUS_OPTIONS()}
+          currentValue={ownerStatus}
+          onChange={v => setOwnerStatus(v as OwnerStatus)}
+        />
+        <div>
+          <label htmlFor="zip">
+            {label(
+              msg('Zip', { desc: 'as in zip code' }),
+              msg(
+                'Your zip code helps determine the amount of discounts and tax credits you qualify for.',
+              ),
+              tooltipSize,
+            )}
+          </label>
+
+          <input
+            tabIndex={0}
+            id="zip"
+            placeholder="12345"
+            name="zip"
+            required
+            type="text"
+            minLength={5}
+            maxLength={5}
+            inputMode="numeric"
+            pattern="[0-9]{5}"
+            autoComplete="postal-code"
+            value={zip}
+            onChange={event => setZip(event.currentTarget.value)}
+          />
+        </div>
+        {renderUtilityField(
+          utility,
+          setUtility,
+          utilitiesFetchState,
+          tooltipSize,
+        )}
+        <div>
+          <label htmlFor="household_income">
+            {label(
+              msg('Household income'),
+              msg(
+                'Enter your gross income (income before taxes). Include wages and salary plus other forms of income, including pensions, interest, dividends, and rental income. If you are married and file jointly, include your spouse’s income.',
+              ),
+              tooltipSize,
+            )}
+          </label>
+          <CurrencyInput
+            placeholder="$60,000"
+            name="household_income"
+            required
+            min={0}
+            max={100000000}
+            value={householdIncome}
+            onChange={setHouseholdIncome}
+          />
+        </div>
+        <Select
+          id="tax_filing"
+          labelSlot={label(
+            msg('Tax filing', { desc: 'form field label' }),
+            msg(
+              'Select "Head of Household" if you have a child or relative living with you, and you pay more than half the costs of your home. Select "Joint" if you file your taxes as a married couple.',
+            ),
+            tooltipSize,
+          )}
+          options={TAX_FILING_OPTIONS()}
+          currentValue={taxFiling}
+          onChange={v => setTaxFiling(v as FilingStatus)}
+        />
+        <Select
+          id="household_size"
+          labelSlot={label(
+            msg('Household size'),
+            msg(
+              'Include anyone you live with who you claim as a dependent on your taxes, and your spouse or partner if you file taxes together.',
+            ),
+            tooltipSize,
+          )}
+          options={HOUSEHOLD_SIZE_OPTIONS()}
+          currentValue={householdSize}
+          onChange={setHouseholdSize}
+        />
+        {showEmailField ? renderEmailField(email, setEmail) : null}
+        <div className="col-start-[-2] col-end-[-1]">
+          <div className="h-0 sm:h-9"></div>
+          <PrimaryButton id="calculate">{msg('Calculate')}</PrimaryButton>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -9,8 +9,8 @@ import { Root } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, APIUtilitiesResponse } from './api/calculator-types-v1';
 import { fetchApi } from './api/fetch';
+import { TextButton } from './buttons';
 import { CalculatorFooter } from './calculator-footer';
-import { CalculatorForm, FormValues, buttonStyles } from './calculator-form';
 import { FilingStatus, OwnerStatus } from './calculator-types';
 import { Card } from './card';
 import { submitEmailSignup, wasEmailSubmitted } from './email-signup';
@@ -21,6 +21,7 @@ import { renderReactElements } from './react-roots';
 import { safeLocalStorage } from './safe-local-storage';
 import { selectStyles } from './select';
 import { Separator } from './separator';
+import { CalculatorForm, FormValues } from './state-calculator-form';
 import {
   StateIncentives,
   stateIncentivesStyles,
@@ -103,7 +104,6 @@ export class RewiringAmericaStateCalculator extends LitElement {
     unsafeCSS(tailwindStyles),
     unsafeCSS(shoelaceTheme),
     baseStyles,
-    buttonStyles,
     inputStyles,
     tooltipStyles,
     selectStyles,
@@ -362,12 +362,9 @@ export class RewiringAmericaStateCalculator extends LitElement {
               {msg('Your household info')}
             </h1>
             <div>
-              <button
-                className="text-button"
-                onClick={() => this.resetFormValues()}
-              >
+              <TextButton onClick={() => this.resetFormValues()}>
                 {msg('Reset')}
-              </button>
+              </TextButton>
             </div>
           </div>
           <div className="text-grey-500 text-[0.75rem] leading-tight pb-[0.1875rem]">
@@ -404,9 +401,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
               );
             }}
             tooltipSize={13}
-            calculateButtonContent={msg('Calculate')}
             onSubmit={values => this.submit(values)}
-            gridClass="grid grid-cols-1 sm:grid-cols-2 gap-4 items-start"
           />
         </Card>
         {this._task.render({

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -4,6 +4,7 @@ import { FC, Key, PropsWithChildren, useState } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, Incentive, ItemType } from './api/calculator-types-v1';
 import { AuthorityLogos } from './authority-logos';
+import { TextButton } from './buttons';
 import { Card } from './card';
 import { wasEmailSubmitted } from './email-signup';
 import { IconTabBar } from './icon-tab-bar';
@@ -14,20 +15,6 @@ import { Separator } from './separator';
 export const stateIncentivesStyles = css`
   /* for now, override these variables just for the state calculator */
   :host {
-    /* labels */
-    --ra-form-label-font-size: 11px;
-    --ra-form-label-line-height: 20px;
-    --ra-form-label-font-weight: 700;
-    --ra-form-label-font-style: normal;
-    --ra-form-label-margin: 8px 0 8px 0;
-    --ra-form-label-text-transform: uppercase;
-    --ra-form-label-letter-spacing: 0.55px;
-    /* button */
-    --ra-embed-primary-button-background-color: var(--rewiring-purple);
-    --ra-embed-primary-button-background-hover-color: var(
-      --rewiring-purple-darker
-    );
-    --ra-embed-primary-button-text-color: white;
     /* select */
     --ra-select-focus-color: var(--rewiring-purple);
     /* input */
@@ -322,9 +309,9 @@ const renderNoResults = (emailSubmitter: ((email: string) => void) | null) => {
           'This could be because there are no incentives in your area, or you don’t financially qualify for any incentives.',
         )}
       </p>
-      <button className="text-button" onClick={scrollToForm}>
+      <TextButton onClick={scrollToForm}>
         {msg('Back to calculator')}
-      </button>
+      </TextButton>
       {emailForm}
     </Card>
   );


### PR DESCRIPTION
## Description

This keeps Tailwind classes out of anything that's used by the old
calculator, which I don't want to convert. It also allows some
simplification in both copies, since a lot of branches can be
eliminated. I probably should have done this a while ago.

I don't know how Github will do at displaying this as a
copy+modify. You may want to pull locally and use `git show -C` to
make use of git's copy detection; it works on this diff.

## Test Plan

Look at old and new forms; make sure they're the same as before.
(There is actually an intentional minor difference: in an earlier
Tailwind PR I broke the alignment of the tooltip icons a little bit,
and this fixes them by making the label div a flexbox.)

Text search to make sure the deleted variables aren't in use by
anything imported by the state calculator.
