### PR TITLE
Reduce new calculator's reliance on shared styles

### DIFF
--- a/src/calculator-footer.tsx
+++ b/src/calculator-footer.tsx
@@ -2,10 +2,11 @@ import { msg } from '@lit/localize';
 
 const toNbsp = (s: string) => s.replace(' ', '\u00a0');
 
+// The semantic class applies on the old embed; Tailwind classes on the new.
 export const CalculatorFooter = () => (
   <slot name="footer">
-    <div className="calculator-footer">
-      <p>
+    <div className="calculator-footer min-w-50 mt-4 text-center">
+      <p className="leading-normal">
         {toNbsp(
           msg('Calculator by', { desc: 'followed by "Rewiring America"' }),
         )}{' '}

--- a/src/calculator.tsx
+++ b/src/calculator.tsx
@@ -15,7 +15,7 @@ import { IncentiveDetails, detailsStyles } from './incentive-details';
 import { IncentiveSummary, summaryStyles } from './incentive-summary';
 import { renderReactElements } from './react-roots';
 import { selectStyles } from './select';
-import { baseStyles, cardStyles, gridStyles } from './styles';
+import { baseStyles, baseVariables, cardStyles, gridStyles } from './styles';
 import { inputStyles } from './styles/input';
 import { tooltipStyles } from './tooltip';
 
@@ -46,6 +46,7 @@ const DEFAULT_CALCULATOR_API_HOST: string = 'https://api.rewiringamerica.org';
 export class RewiringAmericaCalculator extends LitElement {
   static override styles = [
     unsafeCSS(shoelaceTheme),
+    baseVariables,
     baseStyles,
     cardStyles,
     gridStyles,

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -3,7 +3,7 @@ import { configureLocalization, localized, msg } from '@lit/localize';
 import SlSpinner from '@shoelace-style/shoelace/dist/react/spinner';
 import tailwindStyles from 'bundle-text:./tailwind.css';
 import shoelaceTheme from 'bundle-text:@shoelace-style/shoelace/dist/themes/light.css';
-import { LitElement, html, unsafeCSS } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { Root } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -22,11 +22,8 @@ import { safeLocalStorage } from './safe-local-storage';
 import { selectStyles } from './select';
 import { Separator } from './separator';
 import { CalculatorForm, FormValues } from './state-calculator-form';
-import {
-  StateIncentives,
-  stateIncentivesStyles,
-} from './state-incentive-details';
-import { baseStyles } from './styles';
+import { StateIncentives } from './state-incentive-details';
+import { baseVariables } from './styles';
 import { inputStyles } from './styles/input';
 import { tooltipStyles } from './tooltip';
 
@@ -103,11 +100,22 @@ export class RewiringAmericaStateCalculator extends LitElement {
   static override styles = [
     unsafeCSS(tailwindStyles),
     unsafeCSS(shoelaceTheme),
-    baseStyles,
+    baseVariables,
     inputStyles,
     tooltipStyles,
     selectStyles,
-    stateIncentivesStyles,
+    css`
+      /* for now, override these variables just for the state calculator */
+      :host {
+        /* select */
+        --ra-select-focus-color: var(--rewiring-purple);
+        /* input */
+        --ra-input-border: 1px solid #e2e2e2;
+        --ra-input-focus-color: var(--rewiring-purple);
+        --ra-input-margin: 0;
+        --ra-input-padding: 0.5rem 0.75rem;
+      }
+    `,
   ];
 
   /**
@@ -358,7 +366,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
       <>
         <Card>
           <div className="flex justify-between items-baseline">
-            <h1 className="text-base sm:text-xl">
+            <h1 className="text-base sm:text-xl font-medium leading-tight">
               {msg('Your household info')}
             </h1>
             <div>
@@ -445,7 +453,7 @@ export class RewiringAmericaStateCalculator extends LitElement {
     this.reactElements.set('calc-root', calculator);
     this.reactElements.set('calc-footer', <CalculatorFooter />);
     return html`
-      <div class="calculator" id="calc-root"></div>
+      <div class="grid gap-4 sm:gap-6 lg:gap-12" id="calc-root"></div>
       <div id="calc-footer"></div>
     `;
   }

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -218,7 +218,7 @@ const renderIncentiveCard = (key: Key, incentive: Incentive) => (
 function scrollToForm(event: React.MouseEvent) {
   const calculator = (
     event.currentTarget.getRootNode() as ShadowRoot
-  )?.querySelector('.calculator');
+  )?.getElementById('calc-root');
 
   if (!calculator) {
     return;

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -1,5 +1,4 @@
 import { msg, str } from '@lit/localize';
-import { css } from 'lit';
 import { FC, Key, PropsWithChildren, useState } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, Incentive, ItemType } from './api/calculator-types-v1';
@@ -11,19 +10,6 @@ import { IconTabBar } from './icon-tab-bar';
 import { ExclamationPoint, UpRightArrow } from './icons';
 import { PROJECTS, Project, shortLabel } from './projects';
 import { Separator } from './separator';
-
-export const stateIncentivesStyles = css`
-  /* for now, override these variables just for the state calculator */
-  :host {
-    /* select */
-    --ra-select-focus-color: var(--rewiring-purple);
-    /* input */
-    --ra-input-border: 1px solid #e2e2e2;
-    --ra-input-focus-color: var(--rewiring-purple);
-    --ra-input-margin: 0;
-    --ra-input-padding: 0.5rem 0.75rem;
-  }
-`;
 
 const formatTitle = (incentive: Incentive) => {
   const item = itemName(incentive.item.type);
@@ -301,10 +287,10 @@ const renderNoResults = (emailSubmitter: ((email: string) => void) | null) => {
 
   return (
     <Card isFlat={true}>
-      <h1 className="text-grey-700 text-xl font-normal">
+      <h1 className="text-grey-700 text-xl font-normal leading-tight text-balance">
         {msg('No incentives available for this project')}
       </h1>
-      <p>
+      <p className="leading-normal">
         {msg(
           'This could be because there are no incentives in your area, or you don’t financially qualify for any incentives.',
         )}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
 
-export const baseStyles = css`
+export const baseVariables = css`
   /* private 'semantic' defaults to use in themes */
   :host {
     --rewiring-yellow: rgb(249, 214, 91);
@@ -88,7 +88,9 @@ export const baseStyles = css`
     width: 100%;
     max-width: 1280px;
   }
+}`;
 
+export const baseStyles = css`
   * {
     box-sizing: border-box;
   }
@@ -160,11 +162,6 @@ export const baseStyles = css`
     .calculator {
       gap: 48px;
     }
-  }
-
-  /* To prevent margin-collapsing. Temporary for React transition. */
-  .react-root {
-    display: grid;
   }
 `;
 


### PR DESCRIPTION
## Description

This is the last of the Tailwind transition, for now. It breaks the
new calculator's dependency on styles shared with the old calculator;
now the only shared parts left are:

- Styles on `:host` (i.e. the web component itself)
- Replacing the default styling of `<input>` elements
- The tooltip and select components

To do this:

- All the h1, h2, and p elements now need explicit Tailwind styles for
  size and line height

- The `calculator` class on the root div needs to be replaced

- The `calculator-footer` class on the footer needs to have Tailwind
  styles in addition to the semantic class name, because it's shared
  by both calculators and the old one doesn't use Tailwind

## Test Plan

Make sure this and prod are pixel-identical at all three sizes,
including the no-results state and the authority logos.

Audit all the `<h1>`, `<h2>` and `<p>` elements in the new calculator
to make sure they have Tailwind styles that set font-size and
line-height.
