### PR TITLE
Make the top-level state calculator mostly React

### DIFF
--- a/src/api/fetch-state.ts
+++ b/src/api/fetch-state.ts
@@ -1,0 +1,15 @@
+export type FetchState<T> =
+  | {
+      state: 'init';
+    }
+  | {
+      state: 'loading';
+    }
+  | {
+      state: 'complete';
+      response: T;
+    }
+  | {
+      state: 'error';
+      message: string;
+    };

--- a/src/card.tsx
+++ b/src/card.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from 'react';
+import { PropsWithChildren, forwardRef } from 'react';
 
 import clsx from 'clsx';
 
@@ -7,13 +7,12 @@ import clsx from 'clsx';
  * a yellow background and no shadow instead. Children are placed in a
  * 1-column grid.
  */
-export const Card: FC<PropsWithChildren<{ id?: string; isFlat?: boolean }>> = ({
-  id,
-  isFlat,
-  children,
-}) => (
+export const Card = forwardRef<
+  HTMLDivElement,
+  PropsWithChildren<{ isFlat?: boolean }>
+>(({ isFlat, children }, ref) => (
   <div
-    id={id}
+    ref={ref}
     className={clsx(
       'rounded-xl',
       'overflow-clip',
@@ -36,4 +35,4 @@ export const Card: FC<PropsWithChildren<{ id?: string; isFlat?: boolean }>> = ({
       {children}
     </div>
   </div>
-);
+));

--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -1,6 +1,7 @@
 import { msg, str } from '@lit/localize';
 import { FC, useEffect, useState } from 'react';
 import { APIUtilitiesResponse } from './api/calculator-types-v1';
+import { FetchState } from './api/fetch-state';
 import { PrimaryButton } from './buttons';
 import { FilingStatus, OwnerStatus } from './calculator-types';
 import { CurrencyInput } from './currency-input';
@@ -57,7 +58,7 @@ const label = (
 const renderUtilityField = (
   utility: string,
   setUtility: (newValue: string) => void,
-  utilitiesFetch: FetchState,
+  utilitiesFetch: FetchState<APIUtilitiesResponse>,
   tooltipSize: number,
 ) => {
   const labelSlot = label(
@@ -148,22 +149,6 @@ const renderEmailField = (email: string, setEmail: (e: string) => void) => (
   </div>
 );
 
-type FetchState =
-  | {
-      state: 'init';
-    }
-  | {
-      state: 'loading';
-    }
-  | {
-      state: 'complete';
-      response: APIUtilitiesResponse;
-    }
-  | {
-      state: 'error';
-      message: string;
-    };
-
 export type FormValues = {
   zip: string;
   ownerStatus: OwnerStatus;
@@ -205,7 +190,9 @@ export const CalculatorForm: FC<{
   const [projects, setProjects] = useState(initialValues.projects ?? []);
   const [email, setEmail] = useState(initialValues.email ?? '');
 
-  const [utilitiesFetchState, setUtilitiesFetchState] = useState<FetchState>({
+  const [utilitiesFetchState, setUtilitiesFetchState] = useState<
+    FetchState<APIUtilitiesResponse>
+  >({
     state: 'init',
   });
 

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -1,14 +1,15 @@
-import { Task, initialState } from '@lit-labs/task';
 import { configureLocalization, localized, msg } from '@lit/localize';
 import SlSpinner from '@shoelace-style/shoelace/dist/react/spinner';
 import tailwindStyles from 'bundle-text:./tailwind.css';
 import shoelaceTheme from 'bundle-text:@shoelace-style/shoelace/dist/themes/light.css';
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { FC, useEffect, useRef, useState } from 'react';
 import { Root } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, APIUtilitiesResponse } from './api/calculator-types-v1';
 import { fetchApi } from './api/fetch';
+import { FetchState } from './api/fetch-state';
 import { TextButton } from './buttons';
 import { CalculatorFooter } from './calculator-footer';
 import { FilingStatus, OwnerStatus } from './calculator-types';
@@ -16,7 +17,7 @@ import { Card } from './card';
 import { submitEmailSignup, wasEmailSubmitted } from './email-signup';
 import { allLocales, sourceLocale, targetLocales } from './locales/locales';
 import * as spanishLocale from './locales/strings/es';
-import { PROJECTS, Project } from './projects';
+import { PROJECTS } from './projects';
 import { renderReactElements } from './react-roots';
 import { safeLocalStorage } from './safe-local-storage';
 import { selectStyles } from './select';
@@ -38,37 +39,6 @@ const { setLocale } = configureLocalization({
         })(),
 });
 
-const loadingTemplate = () => (
-  <Card>
-    <SlSpinner className="mx-auto text-3xl" />
-  </Card>
-);
-const errorTemplate = (error: unknown) => (
-  <Card id="error-message">
-    {typeof error === 'object' && error && 'message' in error && error.message
-      ? (error.message as string)
-      : msg('Error loading incentives.')}
-  </Card>
-);
-/**
- * Waits for the next event loop (to allow the DOM to update following an
- * update of reactive properties), then scrolls to the element matching the
- * given selector.
- */
-const waitAndScrollTo = (shadowRoot: ShadowRoot, selector: string) => {
-  setTimeout(() => {
-    const target = shadowRoot.querySelector(selector);
-    if (target) {
-      scrollIntoView(target, {
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-        scrollMode: 'if-needed',
-      });
-    }
-  }, 10); // To let the React render happen
-};
-
 const DEFAULT_CALCULATOR_API_HOST: string = 'https://api.rewiringamerica.org';
 const DEFAULT_ZIP = '';
 const DEFAULT_OWNER_STATUS: OwnerStatus = 'homeowner';
@@ -78,19 +48,9 @@ const DEFAULT_HOUSEHOLD_SIZE = '1';
 const DEFAULT_UTILITY = '';
 
 const FORM_VALUES_LOCAL_STORAGE_KEY = 'RA-calc-form-values';
-type SavedFormValues = Partial<{
-  zip: string;
-  ownerStatus: OwnerStatus;
-  householdIncome: string;
-  householdSize: string;
-  taxFiling: FilingStatus;
-  projects: Project[];
-  utility: string;
-}>;
-
 declare module './safe-local-storage' {
   interface SafeLocalStorageMap {
-    [FORM_VALUES_LOCAL_STORAGE_KEY]: SavedFormValues;
+    [FORM_VALUES_LOCAL_STORAGE_KEY]: Partial<FormValues>;
   }
 }
 
@@ -149,49 +109,27 @@ export class RewiringAmericaStateCalculator extends LitElement {
   @property({ type: String, attribute: 'state' })
   state: string = '';
 
-  /* supported properties to allow pre-filling the form
-   *
-   * These can be overridden by values stored in local storage, which is why
-   * they can't use the "attribute" property in the decorator.
-   */
+  /* supported properties to allow pre-filling the form */
 
-  @property({ type: String }) // attribute: 'zip'
+  @property({ type: String, attribute: 'zip' })
   zip: string = DEFAULT_ZIP;
 
-  @property({ type: String }) // attribute: 'owner-status'
+  @property({ type: String, attribute: 'owner-status' })
   ownerStatus: OwnerStatus = DEFAULT_OWNER_STATUS;
 
-  @property({ type: String }) // attribute: 'household-income'
+  @property({ type: String, attribute: 'household-income' })
   householdIncome: string = DEFAULT_HOUSEHOLD_INCOME;
 
-  @property({ type: String }) // attribute: 'tax-filing'
+  @property({ type: String, attribute: 'tax-filing' })
   taxFiling: FilingStatus = DEFAULT_TAX_FILING;
 
-  @property({ type: String }) // attribute: 'household-size'
+  @property({ type: String, attribute: 'household-size' })
   householdSize: string = DEFAULT_HOUSEHOLD_SIZE;
-
-  /* internal properties */
-
-  @property({ type: String })
-  utility: string = DEFAULT_UTILITY;
-
-  @property({ type: Array })
-  projects: Project[] = [];
-
-  @property({ type: String })
-  selectedProjectTab: Project | undefined;
-
-  @property({ type: String })
-  selectedOtherTab: Project | undefined;
-
-  @property({ type: Boolean })
-  wasEmailSubmitted: boolean = wasEmailSubmitted();
 
   /**
    * For the React transition; see react-roots.ts for detail.
    * TODO: this whole mechanism can go away post-React transition
    */
-  reactElements: Map<string, React.ReactElement> = new Map();
   reactRoots: Map<string, { reactRoot: Root; domNode: HTMLElement }> =
     new Map();
 
@@ -211,88 +149,6 @@ export class RewiringAmericaStateCalculator extends LitElement {
   }
 
   /**
-   * Called when the component is added to the DOM. At this point the values of
-   * the HTML attributes are available, so we can initialize the properties
-   * representing form values.
-   */
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this.initFormProperties();
-  }
-
-  /**
-   * Populate the properties that hold form values from saved values if
-   * available, then from HTML attributes if defined, and default values
-   * otherwise.
-   */
-  initFormProperties(): void {
-    const formValues = safeLocalStorage.getItem(FORM_VALUES_LOCAL_STORAGE_KEY);
-    const attr = (k: string) => this.attributes.getNamedItem(k)?.value;
-
-    this.zip = formValues?.zip ?? attr('zip') ?? DEFAULT_ZIP;
-    this.ownerStatus =
-      formValues?.ownerStatus ??
-      (attr('owner-status') as OwnerStatus) ??
-      DEFAULT_OWNER_STATUS;
-    this.householdIncome =
-      formValues?.householdIncome ??
-      attr('household-income') ??
-      DEFAULT_HOUSEHOLD_INCOME;
-    this.householdSize =
-      formValues?.householdSize ??
-      attr('household-size') ??
-      DEFAULT_HOUSEHOLD_SIZE;
-    this.taxFiling =
-      formValues?.taxFiling ??
-      (attr('tax-filing') as FilingStatus) ??
-      DEFAULT_TAX_FILING;
-    this.projects = formValues?.projects ?? [];
-    this.utility = formValues?.utility ?? DEFAULT_UTILITY;
-
-    // Force a re-render of the form
-    this.formKey++;
-  }
-
-  submit(formValues: FormValues) {
-    this.zip = formValues.zip;
-    this.ownerStatus = formValues.ownerStatus;
-    this.householdIncome = formValues.householdIncome;
-    this.householdSize = formValues.householdSize;
-    this.taxFiling = formValues.taxFiling;
-    this.utility = formValues.utility || '';
-    this.projects = formValues.projects || [];
-
-    safeLocalStorage.setItem(FORM_VALUES_LOCAL_STORAGE_KEY, formValues);
-
-    const email = formValues.email;
-    if (email && !this.wasEmailSubmitted) {
-      submitEmailSignup(this.apiHost, this.apiKey, email, this.zip);
-      // This hides the email field
-      this.wasEmailSubmitted = true;
-    }
-
-    this._task.run();
-
-    this.dispatchEvent(
-      new CustomEvent('calculator-submitted', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          formData: formValues,
-        },
-      }),
-    );
-  }
-
-  resetFormValues() {
-    safeLocalStorage.removeItem(FORM_VALUES_LOCAL_STORAGE_KEY);
-    this.initFormProperties();
-    this.dispatchEvent(
-      new Event('calculator-reset', { bubbles: true, composed: true }),
-    );
-  }
-
-  /**
    * Make sure the locale is set before rendering begins. setLocale() is async
    * and this is the only async part of the component lifecycle we can hook.
    */
@@ -304,160 +160,286 @@ export class RewiringAmericaStateCalculator extends LitElement {
   override async updated() {
     renderReactElements(
       this.renderRoot as ShadowRoot,
-      this.reactElements,
-      this.reactRoots,
-    );
-  }
-
-  isFormComplete() {
-    return !!(
-      this.zip &&
-      this.ownerStatus &&
-      this.taxFiling &&
-      this.householdIncome &&
-      this.householdSize &&
-      this.projects
-    );
-  }
-
-  private _task = new Task(this, {
-    autoRun: false,
-    task: async () => {
-      if (!this.isFormComplete()) {
-        // this is a special response type provided by Task to keep it in the INITIAL state
-        return initialState;
-      }
-
-      const query = new URLSearchParams({
-        language: this.lang,
-        include_beta_states: '' + this.includeBetaStates,
-        'location[zip]': this.zip,
-        owner_status: this.ownerStatus,
-        household_income: this.householdIncome,
-        tax_filing: this.taxFiling,
-        household_size: this.householdSize,
-      });
-      if (this.utility) {
-        query.set('utility', this.utility);
-      }
-      Object.values(PROJECTS).forEach(project => {
-        project.items.forEach(item => {
-          query.append('items', item);
-        });
-      });
-
-      return fetchApi<APIResponse>(
-        this.apiKey,
-        this.apiHost,
-        '/api/v1/calculator',
-        query,
-      );
-    },
-    onComplete: () =>
-      waitAndScrollTo(
-        this.shadowRoot!,
-        '#interested-incentives, #other-incentives',
-      ),
-    onError: () => waitAndScrollTo(this.shadowRoot!, '#error-message'),
-  });
-
-  override render() {
-    const calculator = (
-      <>
-        <Card>
-          <div className="flex justify-between items-baseline">
-            <h1 className="text-base sm:text-xl font-medium leading-tight">
-              {msg('Your household info')}
-            </h1>
-            <div>
-              <TextButton onClick={() => this.resetFormValues()}>
-                {msg('Reset')}
-              </TextButton>
-            </div>
-          </div>
-          <div className="text-grey-500 text-[0.75rem] leading-tight pb-[0.1875rem]">
-            {msg(
-              'We’re dedicated to safeguarding your privacy. We never share or sell your personal information.',
-            )}
-          </div>
-          <CalculatorForm
-            key={this.formKey}
-            stateId={this.state}
-            initialValues={{
+      new Map([
+        [
+          'calc-root',
+          <StateCalculator
+            shadowRoot={this.renderRoot as ShadowRoot}
+            language={this.lang}
+            apiHost={this.apiHost}
+            apiKey={this.apiKey}
+            attributeValues={{
               zip: this.zip,
               ownerStatus: this.ownerStatus,
               householdIncome: this.householdIncome,
               householdSize: this.householdSize,
               taxFiling: this.taxFiling,
-              utility: this.utility,
-              projects: this.projects,
             }}
-            showEmailField={this.showEmail && !this.wasEmailSubmitted}
-            showProjectField={true}
-            utilityFetcher={zip => {
-              const query = new URLSearchParams({
-                language: this.lang,
-                include_beta_states: '' + this.includeBetaStates,
-                'location[zip]': zip,
-              });
-
-              return fetchApi<APIUtilitiesResponse>(
-                this.apiKey,
-                this.apiHost,
-                '/api/v1/utilities',
-                query,
-              );
-            }}
-            tooltipSize={13}
-            onSubmit={values => this.submit(values)}
-          />
-        </Card>
-        {this._task.render({
-          initial: () => null,
-          pending: loadingTemplate,
-          error: errorTemplate,
-          complete: response => (
-            <>
-              <Separator />
-              <StateIncentives
-                response={response}
-                selectedProjects={this.projects}
-                selectedProjectTab={this.selectedProjectTab}
-                onTabSelected={newSelection =>
-                  (this.selectedProjectTab = newSelection)
-                }
-                selectedOtherTab={this.selectedOtherTab}
-                onOtherTabSelected={newOtherSelection =>
-                  (this.selectedOtherTab = newOtherSelection)
-                }
-                emailSubmitter={
-                  this.showEmail
-                    ? (email: string) => {
-                        submitEmailSignup(
-                          this.apiHost,
-                          this.apiKey,
-                          email,
-                          this.zip,
-                        );
-                        this.wasEmailSubmitted = true;
-                      }
-                    : null
-                }
-              />
-            </>
-          ),
-        })}
-      </>
+            stateId={this.state}
+            showEmail={this.showEmail}
+            includeBetaStates={this.includeBetaStates}
+          />,
+        ],
+        ['calc-footer', <CalculatorFooter />],
+      ]),
+      this.reactRoots,
     );
+  }
 
-    this.reactElements.set('calc-root', calculator);
-    this.reactElements.set('calc-footer', <CalculatorFooter />);
+  override render() {
     return html`
-      <div class="grid gap-4 sm:gap-6 lg:gap-12" id="calc-root"></div>
+      <div id="calc-root" class="grid gap-4 sm:gap-6 lg:gap-12"></div>
       <div id="calc-footer"></div>
     `;
   }
 }
+
+const fetch = (
+  apiHost: string,
+  apiKey: string,
+  language: string,
+  includeBetaStates: boolean,
+  formValues: FormValues,
+  setFetchState: (fs: FetchState<APIResponse>) => void,
+) => {
+  if (
+    !(
+      formValues.zip &&
+      formValues.ownerStatus &&
+      formValues.taxFiling &&
+      formValues.householdIncome &&
+      formValues.householdSize &&
+      formValues.projects
+    )
+  ) {
+    return;
+  }
+
+  setFetchState({ state: 'loading' });
+
+  const query = new URLSearchParams({
+    language,
+    include_beta_states: '' + includeBetaStates,
+    'location[zip]': formValues.zip,
+    owner_status: formValues.ownerStatus,
+    household_income: formValues.householdIncome,
+    tax_filing: formValues.taxFiling,
+    household_size: formValues.householdSize,
+  });
+  if (formValues.utility) {
+    query.set('utility', formValues.utility);
+  }
+  Object.values(PROJECTS).forEach(project => {
+    project.items.forEach(item => {
+      query.append('items', item);
+    });
+  });
+
+  return fetchApi<APIResponse>(apiKey, apiHost, '/api/v1/calculator', query)
+    .then(response => setFetchState({ state: 'complete', response }))
+    .catch(exc => setFetchState({ state: 'error', message: exc.message }));
+};
+
+export const StateCalculator: FC<{
+  shadowRoot: ShadowRoot;
+  language: string;
+  apiHost: string;
+  apiKey: string;
+  attributeValues: Partial<FormValues>;
+  stateId?: string;
+  showEmail: boolean;
+  includeBetaStates: boolean;
+}> = ({
+  shadowRoot,
+  language,
+  apiHost,
+  apiKey,
+  attributeValues,
+  stateId,
+  showEmail,
+  includeBetaStates,
+}) => {
+  // Used to reset the form state to defaults
+  const [formKey, setFormKey] = useState(0);
+
+  const [emailSubmitted, setEmailSubmitted] = useState(wasEmailSubmitted());
+  const [submittedFormValues, setSubmittedFormValues] =
+    useState<FormValues | null>(null);
+  const [fetchState, setFetchState] = useState<FetchState<APIResponse>>({
+    state: 'init',
+  });
+
+  // First read the values from local storage, falling back to the values in
+  // the Lit element's HTML attributes, falling back to hardcoded defaults.
+  const getInitialFormValues = () => {
+    const storedValues = safeLocalStorage.getItem(
+      FORM_VALUES_LOCAL_STORAGE_KEY,
+    );
+
+    return {
+      zip: storedValues?.zip ?? attributeValues.zip ?? DEFAULT_ZIP,
+      ownerStatus:
+        storedValues?.ownerStatus ??
+        attributeValues.ownerStatus ??
+        DEFAULT_OWNER_STATUS,
+      householdIncome:
+        storedValues?.householdIncome ??
+        attributeValues.householdIncome ??
+        DEFAULT_HOUSEHOLD_INCOME,
+      householdSize:
+        storedValues?.householdSize ??
+        attributeValues.householdSize ??
+        DEFAULT_HOUSEHOLD_SIZE,
+      taxFiling:
+        storedValues?.taxFiling ??
+        attributeValues.taxFiling ??
+        DEFAULT_TAX_FILING,
+      projects: storedValues?.projects ?? [],
+      utility: storedValues?.utility ?? DEFAULT_UTILITY,
+    };
+  };
+
+  // Incrementing the form key will cause the form to drop its state,
+  // reinitializing the input values from initial (constructed above).
+  const resetFormValues = () => {
+    safeLocalStorage.removeItem(FORM_VALUES_LOCAL_STORAGE_KEY);
+    setFormKey(fk => fk + 1);
+    shadowRoot.dispatchEvent(
+      new Event('calculator-reset', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+
+  const submit = (formValues: FormValues) => {
+    setSubmittedFormValues(formValues);
+    safeLocalStorage.setItem(FORM_VALUES_LOCAL_STORAGE_KEY, formValues);
+
+    const email = formValues.email;
+    if (email && !emailSubmitted) {
+      submitEmailSignup(apiHost, apiKey, email, formValues.zip);
+      // This hides the email field
+      setEmailSubmitted(true);
+    }
+
+    fetch(
+      apiHost,
+      apiKey,
+      language,
+      includeBetaStates,
+      formValues,
+      setFetchState,
+    );
+
+    shadowRoot.dispatchEvent(
+      new CustomEvent('calculator-submitted', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          formData: formValues,
+        },
+      }),
+    );
+  };
+
+  // When the fetch completes or errors out, scroll to the appropriate element
+  const firstResultsRef = useRef<HTMLDivElement>(null);
+  const secondResultsRef = useRef<HTMLDivElement>(null);
+  const errorMessageRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const target =
+      fetchState.state === 'complete' &&
+      (firstResultsRef.current || secondResultsRef.current)
+        ? firstResultsRef.current ?? secondResultsRef.current
+        : fetchState.state === 'error' && errorMessageRef.current
+        ? errorMessageRef.current
+        : null;
+
+    if (target) {
+      scrollIntoView(target, {
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+        scrollMode: 'if-needed',
+      });
+    }
+  }, [fetchState.state]);
+
+  return (
+    <>
+      <Card>
+        <div className="flex justify-between items-baseline">
+          <h1 className="text-base sm:text-xl font-medium leading-tight">
+            {msg('Your household info')}
+          </h1>
+          <div>
+            <TextButton onClick={resetFormValues}>{msg('Reset')}</TextButton>
+          </div>
+        </div>
+        <div className="text-grey-500 text-[0.75rem] leading-tight pb-[0.1875rem]">
+          {msg(
+            'We’re dedicated to safeguarding your privacy. We never share or sell your personal information.',
+          )}
+        </div>
+        <CalculatorForm
+          key={formKey}
+          stateId={stateId}
+          initialValues={getInitialFormValues()}
+          showEmailField={!!showEmail && !emailSubmitted}
+          showProjectField={true}
+          utilityFetcher={zip => {
+            const query = new URLSearchParams({
+              language,
+              include_beta_states: '' + includeBetaStates,
+              'location[zip]': zip,
+            });
+
+            return fetchApi<APIUtilitiesResponse>(
+              apiKey,
+              apiHost,
+              '/api/v1/utilities',
+              query,
+            );
+          }}
+          tooltipSize={13}
+          onSubmit={submit}
+        />
+      </Card>
+      {fetchState.state === 'init' ? null : fetchState.state === 'loading' ? (
+        <Card>
+          <SlSpinner className="mx-auto text-3xl" />
+        </Card>
+      ) : fetchState.state === 'error' ? (
+        <Card ref={errorMessageRef}>{fetchState.message}</Card>
+      ) : (
+        <>
+          <Separator />
+          <StateIncentives
+            firstResultsRef={firstResultsRef}
+            secondResultsRef={secondResultsRef}
+            response={fetchState.response}
+            selectedProjects={submittedFormValues!.projects ?? []}
+            emailSubmitter={
+              showEmail
+                ? (email: string) => {
+                    submitEmailSignup(
+                      apiHost,
+                      apiKey,
+                      email,
+                      submittedFormValues!.zip,
+                    );
+                    setEmailSubmitted(true);
+                  }
+                : null
+            }
+          />
+        </>
+      )}
+    </>
+  );
+};
 
 /**
  * Tell TypeScript that the HTML tag's type signature corresponds to the


### PR DESCRIPTION
## Description

There's still a Lit element, but it's now a very thin wrapper around a
React component. The React component maintains all the mutable state,
manages the API fetching and local storage, and scrolls the page. The
Lit element basically just forwards the HTML attribute values to the
React component, responds to changes in them, and renders the React
element.

This cleans up some hacks, including:

- No need for the hacky `waitAndScrollTo` stuff, because we can use
  `useEffect` to wait until the DOM nodes are on the page, and refs to
  find the target nodes.

- The Lit element's properties can all be read from HTML attributes
  automatically now, because changing them doesn't interfere with the
  calculator UI's state management.

- The management of the icon-tab-bar state is pushed down a level into
  `StateIncentives`. It was previously in the top-level Lit element
  because that was the easiest place to keep mutable state. This
  separates concerns much better.

## Test Plan

- Cypress tests.

- Make sure the window still scrolls to the results section when
  loading completes.

- Change the `rewiring-america-state-calculator` 's `lang` attribute
  on the live page and make sure the strings become Spanish
  immediately.

- Change the calculator element's other attributes (e.g. `zip`) and
  make sure the form does _not_ update immediately. Submit the form
  and make sure whatever is currently in the field gets sent in the
  network request. Click Reset and make sure the new attribute value
  shows up in the field.
