### PR TITLE
Two small fixes to the old embed

### DIFF
--- a/src/incentive-details.tsx
+++ b/src/incentive-details.tsx
@@ -80,7 +80,7 @@ function formatAmount(amount: number, amount_type: AmountType) {
       return `$${amount.toLocaleString()}`;
     }
   } else {
-    return amount.toString();
+    return `$${amount.toLocaleString()}`;
   }
 }
 
@@ -103,13 +103,16 @@ function formatStartDate(start_date: number, type: IncentiveType) {
   }
 }
 
+const absoluteRewiringURL = (path: string) =>
+  new URL(path, 'https://www.rewiringamerica.org').toString();
+
 const renderDetailRow = (key: number, incentive: IIncentiveRecord) => (
   <tr key={key} className={incentive.eligible ? '' : 'row--dimmed'}>
     <td>
       <a
         className="more-info-link"
         target="_blank"
-        href="https://www.rewiringamerica.org/${incentive.more_info_url}"
+        href={absoluteRewiringURL(incentive.more_info_url)}
       >
         {incentive.item}
       </a>
@@ -124,7 +127,7 @@ const renderDetailRow = (key: number, incentive: IIncentiveRecord) => (
       <a
         className="more-info-button"
         target="_blank"
-        href="https://www.rewiringamerica.org/${incentive.more_info_url}"
+        href={absoluteRewiringURL(incentive.more_info_url)}
       >
         More Info
       </a>


### PR DESCRIPTION
## Description

- Fix formatting of solar tax credit amount. This is a longstanding bug.

- Fix the URLs in the detail rows; I broke this during the React
  conversion. Now constructing them using the `URL` class instead of
  piecing them together manually.

## Test Plan

Look at `/index.html` and make sure:

- The "Rooftop Solar Installation" row has a nicely formatted dollar amount

- The links in the leftmost and rightmost columns work and go to the right pages.
