### PR TITLE
Fix compliance with the "state" attribute

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -135,4 +135,35 @@ describe('rewiring-america-state-calculator', () => {
       .contains('Your household info')
       .isInViewport();
   });
+
+  it('shows an error if you query in the wrong state', () => {
+    cy.intercept({ pathname: '/api/v1/utilities' }).as('utilitiesFetch');
+
+    // Add the state-restricting attribute to the element
+    cy.get('rewiring-america-state-calculator').invoke('attr', 'state', 'RI');
+
+    cy.get('rewiring-america-state-calculator')
+      .shadow()
+      .find('#zip')
+      .type('94306'); // California
+
+    cy.wait('@utilitiesFetch');
+
+    // This error message is displayed under the utility selector, but it's
+    // inside a shadow DOM so this won't find it. This is to prove that the
+    // utility selector error is not what the final assertion below is finding.
+    cy.get('rewiring-america-state-calculator')
+      .shadow()
+      .contains('That ZIP code is not in Rhode Island')
+      .should('not.exist');
+
+    cy.get('rewiring-america-state-calculator')
+      .shadow()
+      .find('button#calculate')
+      .click();
+
+    cy.get('rewiring-america-state-calculator')
+      .shadow()
+      .contains('That ZIP code is not in Rhode Island.');
+  });
 });


### PR DESCRIPTION
## Description

The "state" attribute, if set, is supposed to cause the calculator to
display an error message (and no incentives) if the user enters a zip
code outside of that state.

This stealthily broke when we moved the utility selector into the main
form. Previously, the top-level error state was displayed when
_either_ the utilities fetch or the main fetch had errored, and the
utilities fetch errored if the state was wrong. After the move, a
failed utilities fetch didn't block the main fetch from happening, and
the main fetch did not check the state attribute.

This adds that check, and also adds a Cypress test because this
restricted-state configuration is kind of obscure and easy to
accidentally break.

## Test Plan

Manually add the `state="RI"` attribute and calculate for a MA zip
code; make sure the error is shown and no incentives are shown.

New Cypress test passes; watch the video to confirm it's testing the
intended thing.
