### PR TITLE
Reimplement <Select> using Headless UI

### DIFF
--- a/cypress/e2e/state-calculator-events.cy.ts
+++ b/cypress/e2e/state-calculator-events.cy.ts
@@ -29,7 +29,10 @@ describe('rewiring-america-state-calculator events', () => {
         expect(event.detail).to.exist;
         expect(event.detail.formData).to.exist;
         expect(event.detail.formData.zip).to.equal('02859');
-        expect(event.detail.formData.projects).to.eql(['ev', 'hvac']);
+        expect(Array.from(event.detail.formData.projects).sort()).to.eql([
+          'ev',
+          'hvac',
+        ]);
       });
   });
 

--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -41,7 +41,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .find('sl-select#utility')
+      .find('button#utility')
       .contains('Rhode Island Energy');
 
     cy.get('rewiring-america-state-calculator')
@@ -137,8 +137,6 @@ describe('rewiring-america-state-calculator', () => {
   });
 
   it('shows an error if you query in the wrong state', () => {
-    cy.intercept({ pathname: '/api/v1/utilities' }).as('utilitiesFetch');
-
     // Add the state-restricting attribute to the element
     cy.get('rewiring-america-state-calculator').invoke('attr', 'state', 'RI');
 
@@ -147,16 +145,6 @@ describe('rewiring-america-state-calculator', () => {
       .find('#zip')
       .type('94306'); // California
 
-    cy.wait('@utilitiesFetch');
-
-    // This error message is displayed under the utility selector, but it's
-    // inside a shadow DOM so this won't find it. This is to prove that the
-    // utility selector error is not what the final assertion below is finding.
-    cy.get('rewiring-america-state-calculator')
-      .shadow()
-      .contains('That ZIP code is not in Rhode Island')
-      .should('not.exist');
-
     cy.get('rewiring-america-state-calculator')
       .shadow()
       .find('button#calculate')
@@ -164,6 +152,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('That ZIP code is not in Rhode Island.');
+      .find('#error-msg')
+      .should('contain.text', 'That ZIP code is not in Rhode Island.');
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -88,21 +88,21 @@ Cypress.Commands.add(
   (projects: string[]) => {
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .find('sl-select#projects')
+      .find('button#projects')
       .click();
 
     projects.forEach(project =>
       cy
         .get('rewiring-america-state-calculator')
         .shadow()
-        .find(`sl-option[value="${project}"]`)
+        .find(`li[data-value="${project}"]`)
         .click(),
     );
 
     // Unfocus the project selector
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .find('sl-select#projects')
+      .find('button#projects')
       .click();
   },
 );

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.6",
+    "@headlessui/react": "^1.7.18",
     "@lit-labs/task": "^2.0.0",
     "@lit/localize": "^0.12.1",
     "@shoelace-style/shoelace": "^2.12.0",
@@ -37,6 +39,7 @@
     ]
   },
   "devDependencies": {
+    "@headlessui/tailwindcss": "^0.2.0",
     "@lit/localize-tools": "^0.7.1",
     "@parcel/transformer-inline-string": "2.10.2",
     "@swc/helpers": "^0.4.14",

--- a/src/card.tsx
+++ b/src/card.tsx
@@ -9,13 +9,13 @@ import clsx from 'clsx';
  */
 export const Card = forwardRef<
   HTMLDivElement,
-  PropsWithChildren<{ isFlat?: boolean }>
->(({ isFlat, children }, ref) => (
+  PropsWithChildren<{ id?: string; isFlat?: boolean }>
+>(({ id, isFlat, children }, ref) => (
   <div
     ref={ref}
+    id={id}
     className={clsx(
       'rounded-xl',
-      'overflow-clip',
       'min-w-52',
       isFlat && 'bg-yellow-200',
       !isFlat && 'bg-white shadow',

--- a/src/components/form-label.tsx
+++ b/src/components/form-label.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx';
+import { FC, PropsWithChildren } from 'react';
+import { TooltipButton } from '../tooltip';
+
+/**
+ * Styles the all-uppercase label for a form field. The label element should be
+ * passed in as the child. Optionally renders a tooltip button after the label.
+ */
+export const FormLabel: FC<
+  PropsWithChildren<{
+    hidden?: boolean;
+    tooltipText?: string;
+  }>
+> = ({ hidden, tooltipText, children }) => (
+  <div
+    className={clsx(
+      'w-fit',
+      'flex',
+      'gap-1',
+      'my-2',
+      'text-xsm',
+      'leading-5',
+      'font-bold',
+      'uppercase',
+      'tracking-[0.55px]',
+      hidden && 'hidden',
+    )}
+  >
+    {children}
+    {tooltipText && <TooltipButton text={tooltipText} iconSize={13} />}
+  </div>
+);

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -1,0 +1,257 @@
+import { flip, useFloating } from '@floating-ui/react-dom';
+import { Listbox, Transition } from '@headlessui/react';
+import SlIcon from '@shoelace-style/shoelace/dist/react/icon';
+import SlSpinner from '@shoelace-style/shoelace/dist/react/spinner';
+import clsx from 'clsx';
+import { Fragment } from 'react';
+import { Check, DownTriangle } from '../icons';
+import { FormLabel } from './form-label';
+
+export type Option<T extends string> = {
+  value: T;
+  label: string;
+  iconURL?: URL;
+};
+
+export type SelectProps<T extends string> = {
+  /**
+   * The HTML id of the focusable element. Also used as the "name" of the
+   * form element.
+   */
+  id: string;
+  options: Option<T>[];
+  /** Shown above the select. */
+  labelText: string;
+  /**
+   * If true, there will be no visible label text, but labelText will be used
+   * as the ARIA label.
+   */
+  hiddenLabel?: boolean;
+  tooltipText?: string;
+  disabled?: boolean;
+  /** Display a loading spinner just to the left of the arrow. */
+  loading?: boolean;
+  /** Shown in the element when nothing is selected, or options is empty. */
+  placeholder?: string;
+  /** Shown below the select element. */
+  helpText?: string;
+} & (
+  | {
+      multiple: false;
+      currentValue: T;
+      onChange: (newValue: T) => void;
+    }
+  | {
+      multiple: true;
+      currentValue: T[];
+      onChange: (newValues: T[]) => void;
+    }
+);
+
+/** Renders the tags in the multiselect. */
+const renderTag = (label: string, iconURL?: URL) => (
+  <div
+    className={clsx(
+      'flex',
+      'gap-2',
+      'px-3',
+      'bg-grey-100',
+      'rounded',
+      'border',
+      'border-grey-200',
+      'items-center',
+      'text-sm',
+      // If this has an icon, it may have long text; let the browser
+      // shrink it as necessary
+      iconURL && 'min-w-0',
+    )}
+  >
+    {iconURL && (
+      <SlIcon className="text-base text-grey-700" src={iconURL.toString()} />
+    )}
+    <span className="whitespace-nowrap overflow-hidden text-ellipsis">
+      {label}
+    </span>
+  </div>
+);
+
+export const Select = <T extends string>({
+  id,
+  options,
+  disabled,
+  loading,
+  multiple,
+  labelText,
+  hiddenLabel,
+  tooltipText,
+  placeholder,
+  helpText,
+  currentValue,
+  onChange,
+}: SelectProps<T>) => {
+  const firstCurrentOption = multiple
+    ? options.find(o => currentValue.includes(o.value))
+    : options.find(o => o.value === currentValue);
+
+  let buttonContents = null;
+  if (multiple) {
+    // Render a tag for the first selected option (if any), followed by a
+    // tag with "+N" if there are additional selected options.
+    if (currentValue.length > 0) {
+      buttonContents = (
+        <div className="grow ml-1 py-1 h-full min-w-0 flex gap-1">
+          {renderTag(firstCurrentOption!.label, firstCurrentOption!.iconURL)}
+          {currentValue.length > 1 && renderTag(`+${currentValue.length - 1}`)}
+        </div>
+      );
+    }
+  } else {
+    if (firstCurrentOption) {
+      buttonContents = (
+        <div className="grow ml-3 flex gap-2 items-center">
+          {firstCurrentOption.iconURL && (
+            <SlIcon
+              className="text-lg text-grey-700"
+              src={firstCurrentOption.iconURL.toString()}
+              aria-hidden={true}
+            />
+          )}
+          <div className={clsx(disabled && 'text-grey-500')}>
+            {firstCurrentOption.label}
+          </div>
+        </div>
+      );
+    }
+  }
+
+  // For positioning the Listbox.Options. It will be below the Listbox.Button
+  // unless there's not enough space, in which case it will be above.
+  const { refs, floatingStyles } = useFloating({
+    middleware: [flip()],
+  });
+
+  return (
+    <div>
+      <Listbox
+        as="div"
+        className="relative"
+        name={id}
+        value={currentValue}
+        disabled={disabled}
+        multiple={multiple}
+        onChange={onChange}
+      >
+        <FormLabel hidden={hiddenLabel} tooltipText={tooltipText}>
+          <Listbox.Label>{labelText}</Listbox.Label>
+        </FormLabel>
+        <Listbox.Button
+          id={id}
+          ref={refs.setReference}
+          className={clsx(
+            'group',
+            'flex',
+            'gap-2',
+            'items-center',
+            'w-full',
+            // TODO make this h-12 once the text inputs are the right height
+            'h-[46px]',
+            'border',
+            'border-grey-200',
+            !disabled && 'hover:border-grey-600',
+            // Move the outline inward to cover up the border
+            'outline-offset-[-1px]',
+            'focus:outline',
+            'focus:outline-2',
+            'focus:outline-purple-500',
+            'rounded',
+            'bg-white',
+          )}
+        >
+          {buttonContents ?? (
+            <div className="grow ml-3 text-left text-grey-500">
+              {placeholder}
+            </div>
+          )}
+          {loading && <SlSpinner />}
+          {/* This will look for the parent element with the "group" class, and
+           * check whether its data-headlessui-state attribute contains "open"
+           */}
+          <div
+            className={clsx(
+              'group-data-open:rotate-180',
+              'mr-3',
+              disabled && 'text-grey-500',
+            )}
+            aria-hidden={true}
+          >
+            <DownTriangle w={11} h={5} />
+          </div>
+        </Listbox.Button>
+        <Transition
+          as={Fragment}
+          enter="transition duration-100 ease"
+          enterFrom="transform scale-90 opacity-0"
+          enterTo="transform scale-100 opacity-100"
+          leave="transition duration-100 ease"
+          leaveFrom="transform scale-100 opacity-100"
+          leaveTo="transform scale-90 opacity-0"
+        >
+          <Listbox.Options
+            ref={refs.setFloating}
+            style={floatingStyles}
+            className={clsx(
+              'z-10',
+              'w-full',
+              'max-h-96', // 384px = up to 9 items without overflow
+              'overflow-y-auto',
+              'cursor-pointer',
+              'bg-white',
+              'shadow-elevation',
+              'rounded',
+              'outline-0',
+              'focus:outline',
+              'focus:outline-2',
+              'focus:outline-purple-500',
+              'py-2',
+            )}
+          >
+            {options.map(o => (
+              <Listbox.Option
+                key={o.value}
+                value={o.value}
+                data-value={o.value}
+                className={clsx(
+                  'flex',
+                  'gap-2',
+                  'items-center',
+                  'ui-active:bg-purple-100',
+                  'px-4',
+                  'py-1.5',
+                )}
+              >
+                {multiple &&
+                  (currentValue.includes(o.value) ? (
+                    <Check w={20} h={20} />
+                  ) : (
+                    <div className="w-5" />
+                  ))}
+                {o.iconURL && (
+                  <SlIcon
+                    className="text-lg text-grey-700"
+                    src={o.iconURL.toString()}
+                  />
+                )}
+                {o.label}
+              </Listbox.Option>
+            ))}
+          </Listbox.Options>
+        </Transition>
+      </Listbox>
+      {helpText && (
+        <div className="mx-3 mt-1 text-grey-400 text-xsm leading-normal">
+          {helpText}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -1,4 +1,4 @@
-import { flip, useFloating } from '@floating-ui/react-dom';
+import { flip, offset, useFloating } from '@floating-ui/react-dom';
 import { Listbox, Transition } from '@headlessui/react';
 import SlIcon from '@shoelace-style/shoelace/dist/react/icon';
 import SlSpinner from '@shoelace-style/shoelace/dist/react/spinner';
@@ -126,13 +126,14 @@ export const Select = <T extends string>({
   // For positioning the Listbox.Options. It will be below the Listbox.Button
   // unless there's not enough space, in which case it will be above.
   const { refs, floatingStyles } = useFloating({
-    middleware: [flip()],
+    middleware: [flip(), offset(1)],
   });
 
   return (
     <div>
       <Listbox
         as="div"
+        className="group"
         name={id}
         value={currentValue}
         disabled={disabled}
@@ -146,7 +147,6 @@ export const Select = <T extends string>({
           id={id}
           ref={refs.setReference}
           className={clsx(
-            'group',
             'flex',
             'gap-2',
             'items-center',
@@ -161,6 +161,9 @@ export const Select = <T extends string>({
             'focus:outline',
             'focus:outline-2',
             'focus:outline-purple-500',
+            'group-data-open:outline',
+            'group-data-open:outline-2',
+            'group-data-open:outline-purple-500',
             'rounded',
             'bg-white',
           )}
@@ -206,9 +209,6 @@ export const Select = <T extends string>({
               'shadow-elevation',
               'rounded',
               'outline-0',
-              'focus:outline',
-              'focus:outline-2',
-              'focus:outline-purple-500',
               'py-2',
             )}
           >

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -3,7 +3,6 @@ import { Listbox, Transition } from '@headlessui/react';
 import SlIcon from '@shoelace-style/shoelace/dist/react/icon';
 import SlSpinner from '@shoelace-style/shoelace/dist/react/spinner';
 import clsx from 'clsx';
-import { Fragment } from 'react';
 import { Check, DownTriangle } from '../icons';
 import { FormLabel } from './form-label';
 
@@ -134,7 +133,6 @@ export const Select = <T extends string>({
     <div>
       <Listbox
         as="div"
-        className="relative"
         name={id}
         value={currentValue}
         disabled={disabled}
@@ -188,19 +186,18 @@ export const Select = <T extends string>({
           </div>
         </Listbox.Button>
         <Transition
-          as={Fragment}
-          enter="transition duration-100 ease"
-          enterFrom="transform scale-90 opacity-0"
-          enterTo="transform scale-100 opacity-100"
-          leave="transition duration-100 ease"
-          leaveFrom="transform scale-100 opacity-100"
-          leaveTo="transform scale-90 opacity-0"
+          className="relative z-10"
+          enter="transition duration-100 ease-in-out"
+          enterFrom="scale-90 opacity-0"
+          enterTo="scale-100 opacity-100"
+          leave="transition duration-100 ease-in-out"
+          leaveFrom="scale-100 opacity-100"
+          leaveTo="scale-90 opacity-0"
         >
           <Listbox.Options
             ref={refs.setFloating}
             style={floatingStyles}
             className={clsx(
-              'z-10',
               'w-full',
               'max-h-96', // 384px = up to 9 items without overflow
               'overflow-y-auto',

--- a/src/icon-tab-bar.tsx
+++ b/src/icon-tab-bar.tsx
@@ -2,8 +2,8 @@ import { msg } from '@lit/localize';
 import SlIcon from '@shoelace-style/shoelace/dist/react/icon';
 import clsx from 'clsx';
 import { FC } from 'react';
+import { Option, Select } from './components/select';
 import { PROJECTS, Project, shortLabel } from './projects';
-import { OptionParam, Select } from './select';
 
 type Props = {
   tabs: Project[];
@@ -56,7 +56,7 @@ export const IconTabBar: FC<Props> = ({ tabs, selectedTab, onTabSelected }) => {
     );
   });
 
-  const options: OptionParam<Project>[] = tabs.map(project => ({
+  const options: Option<Project>[] = tabs.map(project => ({
     value: project,
     label: PROJECTS[project].label(),
     iconURL: PROJECTS[project].iconURL,
@@ -73,7 +73,9 @@ export const IconTabBar: FC<Props> = ({ tabs, selectedTab, onTabSelected }) => {
       <div className="sm:hidden mb-6">
         <Select
           id="project-selector"
-          aria-label={msg('Project', { desc: 'label for a selector input' })}
+          labelText={msg('Project', { desc: 'label for a selector input' })}
+          hiddenLabel={true}
+          multiple={false}
           currentValue={selectedTab}
           options={options}
           onChange={project => onTabSelected(project)}

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -149,3 +149,33 @@ export const UpRightArrow: FC<IconProps> = ({ w, h }) => (
     />
   </svg>
 );
+
+export const DownTriangle: FC<IconProps> = ({ w, h }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={w}
+    height={h}
+    viewBox="0 0 11 5"
+    fill="none"
+  >
+    <path d="M0 0H11L5.5 5L0 0Z" fill="currentColor" />
+  </svg>
+);
+
+export const Check: FC<IconProps> = ({ w, h }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={w}
+    height={h}
+    viewBox="0 0 20 20"
+    fill="none"
+  >
+    <path
+      d="M16.6667 5.83334L7.50004 15L3.33337 10.8333"
+      stroke="#6B6B6B"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -20,7 +20,6 @@ import * as spanishLocale from './locales/strings/es';
 import { PROJECTS } from './projects';
 import { renderReactElements } from './react-roots';
 import { safeLocalStorage } from './safe-local-storage';
-import { selectStyles } from './select';
 import { Separator } from './separator';
 import { CalculatorForm, FormValues } from './state-calculator-form';
 import { StateIncentives } from './state-incentive-details';
@@ -64,12 +63,9 @@ export class RewiringAmericaStateCalculator extends LitElement {
     baseVariables,
     inputStyles,
     tooltipStyles,
-    selectStyles,
     css`
       /* for now, override these variables just for the state calculator */
       :host {
-        /* select */
-        --ra-select-focus-color: var(--rewiring-purple);
         /* input */
         --ra-input-border: 1px solid #e2e2e2;
         --ra-input-focus-color: var(--rewiring-purple);
@@ -418,7 +414,6 @@ export const StateCalculator: FC<{
               query,
             );
           }}
-          tooltipSize={13}
           onSubmit={submit}
         />
       </Card>
@@ -427,7 +422,9 @@ export const StateCalculator: FC<{
           <SlSpinner className="mx-auto text-3xl" />
         </Card>
       ) : fetchState.state === 'error' ? (
-        <Card ref={errorMessageRef}>{fetchState.message}</Card>
+        <Card ref={errorMessageRef} id="error-msg">
+          {fetchState.message}
+        </Card>
       ) : (
         <>
           <Separator />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,9 +12,14 @@ module.exports = {
         `rgb(var(--${color}) / <alpha-value>)`,
       ]),
     ),
+    data: {
+      open: 'headlessui-state~="open"',
+    },
     extend: {
       boxShadow: {
         DEFAULT: '0px 0px 15px 0px rgba(0, 0, 0, 0.08)',
+        elevation:
+          '0px 5px 5px -3px rgba(0, 0, 0, 0.20), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12)',
       },
       fontSize: {
         xsm: '0.6875rem', // 11px
@@ -35,5 +40,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@headlessui/tailwindcss')],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,13 @@
   dependencies:
     "@floating-ui/utils" "^0.1.3"
 
+"@floating-ui/core@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.3.tgz#b6aa0827708d70971c8679a16cf680a515b8a52a"
+  integrity sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==
+  dependencies:
+    "@floating-ui/utils" "^0.2.0"
+
 "@floating-ui/dom@^1.5.3":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
@@ -129,10 +136,43 @@
     "@floating-ui/core" "^1.4.2"
     "@floating-ui/utils" "^0.1.3"
 
+"@floating-ui/dom@^1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.4.tgz#28df1e1cb373884224a463235c218dcbd81a16bb"
+  integrity sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==
+  dependencies:
+    "@floating-ui/core" "^1.5.3"
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/react-dom@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.6.tgz#5ffcf40b6550817a973b54cdd443374f51ca7a5c"
+  integrity sha512-IB8aCRFxr8nFkdYZgH+Otd9EVQPJoynxeFRGTB8voPoZMRWo8XjYuCRgpI1btvuKY69XMiLnW+ym7zoBHM90Rw==
+  dependencies:
+    "@floating-ui/dom" "^1.5.4"
+
 "@floating-ui/utils@^0.1.3":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+
+"@floating-ui/utils@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
+  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
+
+"@headlessui/react@^1.7.18":
+  version "1.7.18"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.18.tgz#30af4634d2215b2ca1aa29d07f33d02bea82d9d7"
+  integrity sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==
+  dependencies:
+    "@tanstack/react-virtual" "^3.0.0-beta.60"
+    client-only "^0.0.1"
+
+"@headlessui/tailwindcss@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/tailwindcss/-/tailwindcss-0.2.0.tgz#2c55c98fd8eee4b4f21ec6eb35a014b840059eec"
+  integrity sha512-fpL830Fln1SykOCboExsWr3JIVeQKieLJ3XytLe/tt1A0XzqUthOftDmjcCYLW62w7mQI7wXcoPXr3tZ9QfGxw==
 
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
@@ -1109,6 +1149,18 @@
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
   integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
 
+"@tanstack/react-virtual@^3.0.0-beta.60":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.2.tgz#e5a979f2585d3f583944840319cddf2c2d1b0e51"
+  integrity sha512-9XbRLPKgnhMwwmuQMnJMv+5a9sitGNCSEtf/AZXzmJdesYk7XsjYHaEDny+IrJzvPNwZliIIDwCRiaUqR3zzCA==
+  dependencies:
+    "@tanstack/virtual-core" "3.0.0"
+
+"@tanstack/virtual-core@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0.tgz#637bee36f0cabf96a1d436887c90f138a7e9378b"
+  integrity sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -1693,6 +1745,11 @@ cli-truncate@^3.1.0:
   dependencies:
     slice-ansi "^5.0.0"
     string-width "^5.0.0"
+
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 clone@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
## Description

I put the new implementation in `src/components`, the idea being this
is where new self-contained UI components can go. `src/select.tsx` is
not used by the new calculator, so it will go away when the old
calculator does.

This conforms to the design system with a few known differences:

- When the Select is open, it doesn't have the purple outline. If
  you're using the keyboard, the _listbox_ gets the purple
  outline. This is because Headless UI focuses the listbox when you're
  navigating it. It is possible to remove the outline from the listbox
  and have the Select's button outlined when it's open, but this
  causes a slight flicker when the listbox closes.

- The Selects should be 48px tall, but they're currently 46px to match
  the text input fields. I'll fix that separately.

I used Floating UI to position the list so it's within the viewport.
It doesn't move when you scroll the page -- I don't think that's
really necessary -- but it's trivial to add if people want.

### Accessibility

One notable change I made for a11y is removing the X buttons in the
multiselect's tags. These tripped the "nested interactable elements"
check -- a button (the X) within a button (the whole control). The
Shoelace implementation was not hitting this because the top-level
element is a div, not a button. We could restore the X button and do
some workaround to get around the check, but it really is a nested
interactable, and that's an annoying experience for screenreader
users. Not sure what to do there. I don't think losing the Xs is a
major loss, but could be convinced otherwise.

I also removed the tooltip for the "Projects you're interested in"
field, because it just said "select the projects you're interested
in", which is pointless.

## Test Plan

Use the element with mouse and keyboard.

- Click the labels and make sure they open the element (this is a
  difference from Shoelace; those labels would only focus the element,
  not open it). Click the tooltip icons and make sure they open the
  tooltip and don't focus the element.

- Make the window just over 640px wide to make the multiselect super
  narrow, and have HVAC selected, along with something alphabetically
  later. This is the worst-case scenario for shrinking the element.

- Change the zip code and observe the loading state in the utility
  selector.

- With VoiceOver, make sure each form element has the label and
  current contents announced, with no extraneous bits announced (like
  icons).

  Honestly I'm not sure how good this screenreader experience is,
  although it does seem cleaner than what Shoelace gave us.

Do all of the above in Chrome, Safari, Firefox, on narrow and wide
layouts. Also do the non-VO stuff in MobileSafari.