### PR TITLE
Show "expected in 2024" chip for performance rebates

### DIFF
--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -121,8 +121,9 @@ const formatIncentiveType = (incentive: Incentive) =>
 
 /** We're special-casing these to hardcode an availability start date */
 const isIRARebate = (incentive: Incentive) =>
-  incentive.payment_methods[0] === 'pos_rebate' &&
-  incentive.authority_type === 'federal';
+  incentive.authority_type === 'federal' &&
+  (incentive.payment_methods[0] === 'pos_rebate' ||
+    incentive.payment_methods[0] === 'performance_rebate');
 
 /** TODO get real dates in the data! */
 const renderStartDate = (incentive: Incentive) =>


### PR DESCRIPTION
## Description

For now the only incentive of this kind is the federal "HER"
efficiency rebates program, which is starting to roll out
state-by-state this year, like the other IRA rebates. Show the same
timeline warning chip.

The old embed already says "2024" for that incentive, which is the
same as it does for the IRA appliance rebates.

https://app.asana.com/0/1204738794846444/1206453631604688

## Test Plan

Search for weatherization projects with a low income; make sure the
"Federal Home Efficiency Rebates" result has the chip.
