### PR TITLE
Get rid of <sl-tooltip>

### DIFF
--- a/src/components/form-label.tsx
+++ b/src/components/form-label.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { FC, PropsWithChildren } from 'react';
-import { TooltipButton } from '../tooltip';
+import { TooltipButton } from './tooltip';
 
 /**
  * Styles the all-uppercase label for a form field. The label element should be
@@ -14,19 +14,19 @@ export const FormLabel: FC<
 > = ({ hidden, tooltipText, children }) => (
   <div
     className={clsx(
+      'relative',
       'w-fit',
       'flex',
+      'items-center',
       'gap-1',
       'my-2',
-      'text-xsm',
       'leading-5',
-      'font-bold',
-      'uppercase',
-      'tracking-[0.55px]',
       hidden && 'hidden',
     )}
   >
-    {children}
-    {tooltipText && <TooltipButton text={tooltipText} iconSize={13} />}
+    <span className="text-xsm font-bold uppercase tracking-[0.55px]">
+      {children}
+    </span>
+    {tooltipText && <TooltipButton text={tooltipText} />}
   </div>
 );

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -1,0 +1,74 @@
+import { flip, offset, shift, useFloating } from '@floating-ui/react-dom';
+import { msg } from '@lit/localize';
+import clsx from 'clsx';
+import { FC, useId, useState } from 'react';
+import { QuestionIcon } from '../icons';
+
+/**
+ * Renders the question mark icon in a button, which shows a popover containing
+ * the given text when clicked. Tabbing away from the button, or clicking
+ * anywhere, will close the popover.
+ */
+export const TooltipButton: FC<{ text: string }> = ({ text }) => {
+  const panelId = useId();
+  const [isOpen, setIsOpen] = useState(false);
+  const { refs, floatingStyles } = useFloating<HTMLButtonElement>({
+    middleware: [flip(), shift(), offset(10)],
+    placement: 'top',
+  });
+
+  return (
+    <>
+      <button
+        ref={refs.setReference}
+        type="button"
+        onClick={() => {
+          // Clicking does not automatically focus the button on MobileSafari.
+          // Focus it explicitly so that the tooltip can be closed by clicking
+          // anywhere else (via the onBlur handler).
+          if (!isOpen) {
+            refs.reference.current!.focus();
+          }
+          setIsOpen(!isOpen);
+        }}
+        onBlur={() => setIsOpen(false)}
+        onKeyDown={e => {
+          // "Escape" is standard; some older browsers use "Esc"
+          if (e.key === 'Escape' || e.key === 'Esc') {
+            setIsOpen(false);
+          }
+        }}
+        aria-label={msg('More information', { desc: 'button caption' })}
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? panelId : undefined}
+      >
+        <span aria-hidden={true}>
+          <QuestionIcon w={13} h={13} />
+        </span>
+      </button>
+      {isOpen && (
+        <div
+          id={panelId}
+          ref={refs.setFloating}
+          style={floatingStyles}
+          className={clsx(
+            'z-10',
+            'w-max',
+            'max-w-70',
+            'bg-white',
+            'shadow-elevation',
+            'rounded-lg',
+            'px-6',
+            'py-6',
+            'leading-7',
+          )}
+          // Tell screenreaders to announce the contents of this panel when
+          // they appear, without the user having to navigate to it.
+          aria-live="polite"
+        >
+          {text}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -26,7 +26,6 @@ import { StateIncentives } from './state-incentive-details';
 import { STATES } from './states';
 import { baseVariables } from './styles';
 import { inputStyles } from './styles/input';
-import { tooltipStyles } from './tooltip';
 
 const { setLocale } = configureLocalization({
   sourceLocale,
@@ -62,7 +61,6 @@ export class RewiringAmericaStateCalculator extends LitElement {
     unsafeCSS(shoelaceTheme),
     baseVariables,
     inputStyles,
-    tooltipStyles,
     css`
       /* for now, override these variables just for the state calculator */
       :host {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,7 @@ module.exports = {
         '4xl': '2.25rem', // 36px
       },
       maxWidth: {
+        70: '17.5rem', // 280px
         78: '19.5rem',
       },
       minWidth: {


### PR DESCRIPTION
## Description

Final step of migrating off Shoelace.

I tried using Headless' Popover component, but that has a bug when
used within shadow DOM (I'm sensing a theme!) where tabbing away from
the popover button throws the focus outside of the shadow DOM root.
I'll file a bug with them.

Fortunately, our use case is extremely simple (most notably, there are
no interactive elements within the popover), so it's fairly easy to
implement manually.

A11y-wise, I think this is a better experience than Shoelace's
component offers. At least, the screen-reading is a little cleaner. I
think it's because Shoelace's DOM is a lot more complex.

## Test Plan

- Make sure the question-mark button is positioned correctly.

- Click the button; make sure the tooltip appears and looks
  right. Click the text label and make sure it doesn't open the
  tooltip and instead focuses the form field.

- With a tooltip open, click in several other places and make sure the
  tooltip disappears:

  - The same tooltip's button
  - On the tooltip itself
  - On a non-interactive part of the page
  - On an interactive part of the page; make sure the usual interaction happens

- Do the above two on a phone (especially MobileSafari which has
  unique behavior re: focusing buttons). Make sure the tooltip is
  always positioned fully in viewport.

- Focus the button by tabbing to it. Hit Space or Enter; make sure
  that opens it. Hit Escape; make sure that closes it. With a tooltip
  open, hit Tab or shift-Tab and make sure that moves focus as
  expected and closes the tooltip.

- Use a screenreader; make sure the button says is announced as "More
  information, collapsed, button" or something like that. Click the
  button and make sure the contents of the tooltip are announced
  without further action.
