### PR TITLE
Prettier: ignore cypress/downloads folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 build
 dist
 .parcel-cache
+cypress/downloads


### PR DESCRIPTION
## Description

Fixes the following error when running `yarn lint` (and therefore `yarn prettier --check .` locally:

```bash
> yarn prettier --check .
```
...
```
Checking formatting...
[warn] cypress/downloads/downloads.html
[warn] Code style issues found in the above file. Forgot to run Prettier?
error Command failed with exit code 1.
```

## Test Plan

run `yarn lint` locally and make sure it works
