### PR TITLE
Make text inputs match design system

### DIFF
--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -186,8 +186,7 @@ export const Select = <T extends string>({
             'gap-2',
             'items-center',
             'w-full',
-            // TODO make this h-12 once the text inputs are the right height
-            'h-[46px]',
+            'h-12',
             'border',
             'border-grey-200',
             !disabled && 'hover:border-grey-600',

--- a/src/components/text-input.tsx
+++ b/src/components/text-input.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import { JSX, forwardRef } from 'react';
+
+/**
+ * This styles text/email input elements with Tailwind styles.
+ *
+ * Although this code is used from the old embed as well, the old embed doesn't
+ * have the Tailwind base layers, so those classes have no effect. Instead the
+ * styles in input.ts are in effect.
+ */
+export const TextInput = forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input'] & { type: 'text' | 'email' }
+>((props, ref) => (
+  <input
+    ref={ref}
+    className={clsx(
+      'w-full',
+      'h-12',
+      'px-3',
+      'pt-px',
+      'rounded',
+      'bg-white',
+      'text-grey-700',
+      'placeholder:text-grey-400',
+      'border',
+      'border-grey-200',
+      !props.disabled && 'hover:border-grey-600',
+      'outline-offset-[-1px]',
+      'focus:outline',
+      'focus:outline-2',
+      'focus:outline-purple-500',
+      props.inputMode === 'numeric' && 'tabular-nums',
+    )}
+    {...props}
+  />
+));

--- a/src/currency-input.tsx
+++ b/src/currency-input.tsx
@@ -1,5 +1,6 @@
 import AutoNumeric from 'autonumeric';
 import { useRef } from 'react';
+import { TextInput } from './components/text-input';
 
 type Props = {
   value: string;
@@ -23,7 +24,7 @@ export function CurrencyInput({
   const autonumericRef = useRef<AutoNumeric | null>(null);
 
   return (
-    <input
+    <TextInput
       ref={ref => {
         if (ref) {
           autonumericRef.current = new AutoNumeric(ref, value, {

--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -5,6 +5,7 @@ import { PrimaryButton } from './buttons';
 import { FilingStatus, OwnerStatus } from './calculator-types';
 import { FormLabel } from './components/form-label';
 import { Option, Select } from './components/select';
+import { TextInput } from './components/text-input';
 import { CurrencyInput } from './currency-input';
 import { str } from './i18n/str';
 import { MsgFn, useTranslated } from './i18n/use-translated';
@@ -110,7 +111,7 @@ const renderEmailField = (
     <FormLabel>
       <label htmlFor="email">{msg('Email address (optional)')}</label>
     </FormLabel>
-    <input
+    <TextInput
       tabIndex={0}
       id="email"
       placeholder={msg('you@example.com', {
@@ -256,7 +257,7 @@ export const CalculatorForm: FC<{
             </label>
           </FormLabel>
 
-          <input
+          <TextInput
             tabIndex={0}
             id="zip"
             placeholder="12345"

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -42,10 +42,7 @@ declare module './safe-local-storage' {
 
 @customElement('rewiring-america-state-calculator')
 export class RewiringAmericaStateCalculator extends LitElement {
-  static override styles = [
-    unsafeCSS(tailwindStyles),
-    baseVariables,
-  ];
+  static override styles = [unsafeCSS(tailwindStyles), baseVariables];
 
   /**
    * Property to control display language. Changing this dynamically is not

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -1,5 +1,5 @@
 import tailwindStyles from 'bundle-text:./tailwind.css';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import { LitElement, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { FC, useEffect, useRef, useState } from 'react';
 import { Root } from 'react-dom/client';
@@ -24,7 +24,6 @@ import { CalculatorForm, FormValues } from './state-calculator-form';
 import { StateIncentives } from './state-incentive-details';
 import { STATES } from './states';
 import { baseVariables } from './styles';
-import { inputStyles } from './styles/input';
 
 const DEFAULT_CALCULATOR_API_HOST: string = 'https://api.rewiringamerica.org';
 const DEFAULT_ZIP = '';
@@ -46,17 +45,6 @@ export class RewiringAmericaStateCalculator extends LitElement {
   static override styles = [
     unsafeCSS(tailwindStyles),
     baseVariables,
-    inputStyles,
-    css`
-      /* for now, override these variables just for the state calculator */
-      :host {
-        /* input */
-        --ra-input-border: 1px solid #e2e2e2;
-        --ra-input-focus-color: var(--rewiring-purple);
-        --ra-input-margin: 0;
-        --ra-input-padding: 0.5rem 0.75rem;
-      }
-    `,
   ];
 
   /**

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -10,6 +10,7 @@ import {
 import { AuthorityLogos } from './authority-logos';
 import { PrimaryButton, TextButton } from './buttons';
 import { Card } from './card';
+import { TextInput } from './components/text-input';
 import { wasEmailSubmitted } from './email-signup';
 import { str } from './i18n/str';
 import { MsgFn, useTranslated } from './i18n/use-translated';
@@ -287,7 +288,7 @@ const renderNoResults = (emailSubmitter: ((email: string) => void) | null) => {
           }}
         >
           <div className="grid gap-4 auto-rows-min">
-            <input
+            <TextInput
               type="email"
               autoComplete="email"
               placeholder={msg('you@example.com', {


### PR DESCRIPTION
## Description

These are the "large" text fields from our design system. Now all the
elements of the form have the same style.

## Test Plan

Look at and use the text input fields on both old and new embeds.

Searched for `<input` to make sure all the relevant instances are converted.
