### PR TITLE
Implement the state calculator component without Lit

### DIFF
--- a/src/i18n/use-translated.ts
+++ b/src/i18n/use-translated.ts
@@ -59,7 +59,7 @@ export const LocaleContext = createContext(sourceLocale);
  * A hook that returns a function to localize strings. All localizable strings
  * should be wrapped in a call to msg().
  */
-export const useTranslated = (): { msg: MsgFn } => {
+export const useTranslated = (): { msg: MsgFn; locale: Locale } => {
   const locale = computeLocale(useContext(LocaleContext));
 
   // This mimics the subset of @lit/localize's msg() function that we use.
@@ -105,5 +105,5 @@ export const useTranslated = (): { msg: MsgFn } => {
         );
   };
 
-  return { msg };
+  return { msg, locale };
 };

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -106,7 +106,7 @@ const StateCalculator: FC<{
   shadowRoot: ShadowRoot;
   apiHost: string;
   apiKey: string;
-  attributeValues: Partial<FormValues>;
+  attributeValues: FormValues;
   stateId?: string;
   showEmail: boolean;
   includeBetaStates: boolean;
@@ -139,23 +139,13 @@ const StateCalculator: FC<{
     );
 
     return {
-      zip: storedValues?.zip ?? attributeValues.zip ?? DEFAULT_ZIP,
-      ownerStatus:
-        storedValues?.ownerStatus ??
-        attributeValues.ownerStatus ??
-        DEFAULT_OWNER_STATUS,
+      zip: storedValues?.zip ?? attributeValues.zip,
+      ownerStatus: storedValues?.ownerStatus ?? attributeValues.ownerStatus,
       householdIncome:
-        storedValues?.householdIncome ??
-        attributeValues.householdIncome ??
-        DEFAULT_HOUSEHOLD_INCOME,
+        storedValues?.householdIncome ?? attributeValues.householdIncome,
       householdSize:
-        storedValues?.householdSize ??
-        attributeValues.householdSize ??
-        DEFAULT_HOUSEHOLD_SIZE,
-      taxFiling:
-        storedValues?.taxFiling ??
-        attributeValues.taxFiling ??
-        DEFAULT_TAX_FILING,
+        storedValues?.householdSize ?? attributeValues.householdSize,
+      taxFiling: storedValues?.taxFiling ?? attributeValues.taxFiling,
       projects: storedValues?.projects ?? [],
       utility: storedValues?.utility ?? DEFAULT_UTILITY,
     };

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -234,7 +234,7 @@ const StateCalculator: FC<{
   }, [fetchState.state]);
 
   return (
-    <>
+    <div id="calc-root" className="grid gap-4 sm:gap-6 lg:gap-12">
       <Card>
         <div className="flex justify-between items-baseline">
           <h1 className="text-base sm:text-xl font-medium leading-tight">
@@ -310,7 +310,7 @@ const StateCalculator: FC<{
           />
         </>
       )}
-    </>
+    </div>
   );
 };
 
@@ -366,11 +366,9 @@ class CalculatorElement extends HTMLElement {
 
     shadowRoot.appendChild(style);
 
-    const calcRoot = document.createElement('div');
-    calcRoot.id = 'calc-root';
-    calcRoot.className = 'grid gap-4 sm:gap-6 lg:gap-12';
-    shadowRoot.appendChild(calcRoot);
-    this.reactRootCalculator = createRoot(calcRoot);
+    const calculator = document.createElement('div');
+    shadowRoot.appendChild(calculator);
+    this.reactRootCalculator = createRoot(calculator);
 
     const footer = document.createElement('div');
     shadowRoot.appendChild(footer);
@@ -394,9 +392,9 @@ class CalculatorElement extends HTMLElement {
     } else if (attr === 'api-key') {
       this.apiKey = newValue ?? '';
     } else if (attr === 'include-beta-states') {
-      this.includeBetaStates = !!newValue;
+      this.includeBetaStates = newValue !== null;
     } else if (attr === 'show-email') {
-      this.showEmail = !!newValue;
+      this.showEmail = newValue !== null;
     } else if (attr === 'state') {
       this.state = newValue ?? '';
     } else if (attr === 'zip') {

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -104,7 +104,6 @@ const fetch = (
 
 const StateCalculator: FC<{
   shadowRoot: ShadowRoot;
-  language: string;
   apiHost: string;
   apiKey: string;
   attributeValues: Partial<FormValues>;
@@ -113,7 +112,6 @@ const StateCalculator: FC<{
   includeBetaStates: boolean;
 }> = ({
   shadowRoot,
-  language,
   apiHost,
   apiKey,
   attributeValues,
@@ -121,7 +119,7 @@ const StateCalculator: FC<{
   showEmail,
   includeBetaStates,
 }) => {
-  const { msg } = useTranslated();
+  const { msg, locale } = useTranslated();
 
   // Used to reset the form state to defaults
   const [formKey, setFormKey] = useState(0);
@@ -190,7 +188,7 @@ const StateCalculator: FC<{
     fetch(
       apiHost,
       apiKey,
-      language,
+      locale,
       stateId ?? null,
       includeBetaStates,
       formValues,
@@ -262,7 +260,7 @@ const StateCalculator: FC<{
           showEmailField={!!showEmail && !emailSubmitted}
           utilityFetcher={zip => {
             const query = new URLSearchParams({
-              language,
+              language: locale,
               include_beta_states: '' + includeBetaStates,
               'location[zip]': zip,
             });
@@ -423,7 +421,6 @@ class CalculatorElement extends HTMLElement {
       <LocaleContext.Provider value={this.lang}>
         <StateCalculator
           shadowRoot={this.shadowRoot!}
-          language={this.lang}
           apiHost={this.apiHost}
           apiKey={this.apiKey}
           attributeValues={{

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -1,8 +1,6 @@
 import tailwindStyles from 'bundle-text:./tailwind.css';
-import { LitElement, html, unsafeCSS } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
 import { FC, useEffect, useRef, useState } from 'react';
-import { Root } from 'react-dom/client';
+import { Root, createRoot } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { APIResponse, APIUtilitiesResponse } from './api/calculator-types-v1';
 import { fetchApi } from './api/fetch';
@@ -17,13 +15,11 @@ import { allLocales } from './i18n/locales';
 import { str } from './i18n/str';
 import { LocaleContext, MsgFn, useTranslated } from './i18n/use-translated';
 import { PROJECTS } from './projects';
-import { renderReactElements } from './react-roots';
 import { safeLocalStorage } from './safe-local-storage';
 import { Separator } from './separator';
 import { CalculatorForm, FormValues } from './state-calculator-form';
 import { StateIncentives } from './state-incentive-details';
 import { STATES } from './states';
-import { baseVariables } from './styles';
 
 const DEFAULT_CALCULATOR_API_HOST: string = 'https://api.rewiringamerica.org';
 const DEFAULT_ZIP = '';
@@ -37,124 +33,6 @@ const FORM_VALUES_LOCAL_STORAGE_KEY = 'RA-calc-form-values';
 declare module './safe-local-storage' {
   interface SafeLocalStorageMap {
     [FORM_VALUES_LOCAL_STORAGE_KEY]: Partial<FormValues>;
-  }
-}
-
-@customElement('rewiring-america-state-calculator')
-export class RewiringAmericaStateCalculator extends LitElement {
-  static override styles = [unsafeCSS(tailwindStyles), baseVariables];
-
-  /**
-   * Property to control display language. Changing this dynamically is not
-   * supported: UI labels and such will change immediately, but user-visible
-   * text that came from API responses will not change until the next API
-   * fetch completes.
-   */
-  @property({ type: String, attribute: 'lang' })
-  override lang: string = this.getDefaultLanguage();
-
-  /* supported property to show the email signup field */
-
-  @property({ type: Boolean, attribute: 'show-email' })
-  showEmail: boolean = false;
-
-  /* property to include incentives from states that aren't formally launched */
-
-  @property({ type: Boolean, attribute: 'include-beta-states' })
-  includeBetaStates: boolean = false;
-
-  /* supported properties to control which API path and key is used to load the calculator results */
-
-  @property({ type: String, attribute: 'api-key' })
-  apiKey: string = '';
-
-  @property({ type: String, attribute: 'api-host' })
-  apiHost: string = DEFAULT_CALCULATOR_API_HOST;
-
-  /* supported property to allow restricting the calculator to ZIPs in a specific state */
-  @property({ type: String, attribute: 'state' })
-  state: string = '';
-
-  /* supported properties to allow pre-filling the form */
-
-  @property({ type: String, attribute: 'zip' })
-  zip: string = DEFAULT_ZIP;
-
-  @property({ type: String, attribute: 'owner-status' })
-  ownerStatus: OwnerStatus = DEFAULT_OWNER_STATUS;
-
-  @property({ type: String, attribute: 'household-income' })
-  householdIncome: string = DEFAULT_HOUSEHOLD_INCOME;
-
-  @property({ type: String, attribute: 'tax-filing' })
-  taxFiling: FilingStatus = DEFAULT_TAX_FILING;
-
-  @property({ type: String, attribute: 'household-size' })
-  householdSize: string = DEFAULT_HOUSEHOLD_SIZE;
-
-  /**
-   * For the React transition; see react-roots.ts for detail.
-   * TODO: this whole mechanism can go away post-React transition
-   */
-  reactRoots: Map<string, { reactRoot: Root; domNode: HTMLElement }> =
-    new Map();
-
-  /**
-   * This is the "key" attribute of the form component. Change it to force a
-   * re-render of the form, dropping the values in its state.
-   */
-  formKey: number = 0;
-
-  private getDefaultLanguage() {
-    const closestLang =
-      (this.closest('[lang]') as HTMLElement | null)?.lang?.split('-')?.[0] ??
-      '';
-    return (allLocales as readonly string[]).includes(closestLang)
-      ? closestLang
-      : 'en';
-  }
-
-  override async updated() {
-    renderReactElements(
-      this.renderRoot as ShadowRoot,
-      new Map([
-        [
-          'calc-root',
-          <LocaleContext.Provider value={this.lang}>
-            <StateCalculator
-              shadowRoot={this.renderRoot as ShadowRoot}
-              language={this.lang}
-              apiHost={this.apiHost}
-              apiKey={this.apiKey}
-              attributeValues={{
-                zip: this.zip,
-                ownerStatus: this.ownerStatus,
-                householdIncome: this.householdIncome,
-                householdSize: this.householdSize,
-                taxFiling: this.taxFiling,
-              }}
-              stateId={this.state}
-              showEmail={this.showEmail}
-              includeBetaStates={this.includeBetaStates}
-            />
-          </LocaleContext.Provider>,
-        ],
-        [
-          'calc-footer',
-          <LocaleContext.Provider value={this.lang}>
-            <CalculatorFooter />
-          </LocaleContext.Provider>,
-        ],
-      ]),
-      this.reactRoots,
-    );
-  }
-
-  override render() {
-    return html`
-      <div id="calc-root" class="grid gap-4 sm:gap-6 lg:gap-12"></div>
-      <div id="calc-footer"></div>
-    `;
   }
 }
 
@@ -224,7 +102,7 @@ const fetch = (
     .catch(exc => setFetchState({ state: 'error', message: exc.message }));
 };
 
-export const StateCalculator: FC<{
+const StateCalculator: FC<{
   shadowRoot: ShadowRoot;
   language: string;
   apiHost: string;
@@ -256,7 +134,7 @@ export const StateCalculator: FC<{
   });
 
   // First read the values from local storage, falling back to the values in
-  // the Lit element's HTML attributes, falling back to hardcoded defaults.
+  // the element's HTML attributes, falling back to hardcoded defaults.
   const getInitialFormValues = () => {
     const storedValues = safeLocalStorage.getItem(
       FORM_VALUES_LOCAL_STORAGE_KEY,
@@ -436,12 +314,158 @@ export const StateCalculator: FC<{
   );
 };
 
+class CalculatorElement extends HTMLElement {
+  /* supported property to switch UI language */
+  override lang: string = this.getDefaultLanguage();
+
+  /* property to show the email signup field */
+  showEmail: boolean = false;
+
+  /* property to include incentives from states that aren't formally launched */
+  includeBetaStates: boolean = false;
+
+  /* supported properties to control which API path and key is used to load the calculator results */
+  apiKey: string = '';
+  apiHost: string = DEFAULT_CALCULATOR_API_HOST;
+
+  /* supported property to allow restricting the calculator to ZIPs in a specific state */
+  state: string = '';
+
+  /* supported properties to allow pre-filling the form */
+  zip: string = DEFAULT_ZIP;
+  ownerStatus: OwnerStatus = DEFAULT_OWNER_STATUS;
+  householdIncome: string = DEFAULT_HOUSEHOLD_INCOME;
+  taxFiling: FilingStatus = DEFAULT_TAX_FILING;
+  householdSize: string = DEFAULT_HOUSEHOLD_SIZE;
+
+  /* attributeChangedCallback() will be called when any of these changes */
+  static observedAttributes = [
+    'lang',
+    'show-email',
+    'include-beta-states',
+    'api-key',
+    'api-host',
+    'state',
+    'zip',
+    'owner-status',
+    'household-income',
+    'tax-filing',
+    'household-size',
+  ] as const;
+
+  reactRootCalculator: Root;
+  reactRootFooter: Root;
+
+  constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({ mode: 'open' });
+
+    const style = document.createElement('style');
+    style.textContent = tailwindStyles;
+
+    shadowRoot.appendChild(style);
+
+    const calcRoot = document.createElement('div');
+    calcRoot.id = 'calc-root';
+    calcRoot.className = 'grid gap-4 sm:gap-6 lg:gap-12';
+    shadowRoot.appendChild(calcRoot);
+    this.reactRootCalculator = createRoot(calcRoot);
+
+    const footer = document.createElement('div');
+    shadowRoot.appendChild(footer);
+    this.reactRootFooter = createRoot(footer);
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  attributeChangedCallback(
+    attr: (typeof CalculatorElement.observedAttributes)[number],
+    _: string | null, // old value; unused
+    newValue: string | null,
+  ) {
+    if (attr === 'lang') {
+      // Don't do anything; the property already reflects the change.
+      // Assigning to lang here will cause infinite recursion.
+    } else if (attr === 'api-host') {
+      this.apiHost = newValue ?? DEFAULT_CALCULATOR_API_HOST;
+    } else if (attr === 'api-key') {
+      this.apiKey = newValue ?? '';
+    } else if (attr === 'include-beta-states') {
+      this.includeBetaStates = !!newValue;
+    } else if (attr === 'show-email') {
+      this.showEmail = !!newValue;
+    } else if (attr === 'state') {
+      this.state = newValue ?? '';
+    } else if (attr === 'zip') {
+      this.zip = newValue ?? DEFAULT_ZIP;
+    } else if (attr === 'owner-status') {
+      this.ownerStatus = (newValue as OwnerStatus) ?? DEFAULT_OWNER_STATUS;
+    } else if (attr === 'household-income') {
+      this.householdIncome = newValue ?? DEFAULT_HOUSEHOLD_INCOME;
+    } else if (attr === 'household-size') {
+      this.householdSize = newValue ?? DEFAULT_HOUSEHOLD_SIZE;
+    } else if (attr === 'tax-filing') {
+      this.taxFiling = (newValue as FilingStatus) ?? DEFAULT_TAX_FILING;
+    } else {
+      // This will fail typechecking if the cases above aren't exhaustive
+      // with respect to observedAttributes
+      const n: never = attr;
+      console.error('Unexpected attribute', n, newValue);
+    }
+    if (this.isConnected) {
+      this.render();
+    }
+  }
+
+  private render() {
+    this.reactRootCalculator.render(
+      <LocaleContext.Provider value={this.lang}>
+        <StateCalculator
+          shadowRoot={this.shadowRoot!}
+          language={this.lang}
+          apiHost={this.apiHost}
+          apiKey={this.apiKey}
+          attributeValues={{
+            zip: this.zip,
+            ownerStatus: this.ownerStatus,
+            householdIncome: this.householdIncome,
+            householdSize: this.householdSize,
+            taxFiling: this.taxFiling,
+          }}
+          stateId={this.state}
+          showEmail={this.showEmail}
+          includeBetaStates={this.includeBetaStates}
+        />
+      </LocaleContext.Provider>,
+    );
+    this.reactRootFooter.render(
+      <LocaleContext.Provider value={this.lang}>
+        <CalculatorFooter />
+      </LocaleContext.Provider>,
+    );
+  }
+
+  private getDefaultLanguage() {
+    const closestLang =
+      (this.closest('[lang]') as HTMLElement | null)?.lang?.split('-')?.[0] ??
+      '';
+    return (allLocales as readonly string[]).includes(closestLang)
+      ? closestLang
+      : 'en';
+  }
+}
+
+customElements.define('rewiring-america-state-calculator', CalculatorElement);
+
 /**
  * Tell TypeScript that the HTML tag's type signature corresponds to the
  * class's type signature.
  */
 declare global {
   interface HTMLElementTagNameMap {
-    'rewiring-america-state-calculator': RewiringAmericaStateCalculator;
+    'rewiring-america-state-calculator': CalculatorElement;
   }
 }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -88,7 +88,7 @@ export const baseVariables = css`
     width: 100%;
     max-width: 1280px;
   }
-}`;
+`;
 
 export const baseStyles = css`
   * {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -56,3 +56,21 @@
   --color-text-secondary: var(--grey-400);
   --color-text-tertiary: var(--yellow-800);
 }
+
+:host {
+  all: initial; /* https://lamplightdev.com/blog/2019/03/26/why-is-my-web-component-inheriting-styles/ */
+  color: black;
+  font-smoothing: antialiased;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'GT America', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  font-size: 16px;
+  line-height: 28px;
+  font-weight: 400;
+  margin: 0 auto; /* center on page */
+  display: block; /* required for max-width to kick in */
+  width: 100%;
+  max-width: 1280px;
+}


### PR DESCRIPTION
## Description

We do not need Lit's update lifecycle management; we have React for
that. This is now a manually-implemented web component whose sole
purpose is to wrap the React component and tell it about updates to
the HTML attributes.

Bundle size is back down to 504K uncompressed, which is smaller than
before the commit where I added React(!) (552K, and that's without
the SVG icons bundled in).

## Test Plan

Grep for imports from `lit` to make sure they're only in files that
are not imported from the new calculator.

- Change the element's `lang` attribute, make sure the UI switches to 
  Spanish.

- Check the "include beta states" box, then enter the ZIP 12084 (NY)
  and make sure the utilities menu populates. Uncheck the box, delete
  and reenter the same ZIP, make sure the utilities menu doesn't
  populate (showing the checkbox takes effect immediately).

- Change one of the form-value attributes and make sure nothing changes
  immediately. Click "reset" and make sure the changed attribute value
  appears in the form.

- Delete all the CSS from `state-calculator.html` and make sure the
  calculator still has the proper styles (i.e. it wasn't accidentally
  relying on inheriting anything from the parent page).