### PR TITLE
Remove savings field from API v1 definition

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -83,11 +83,5 @@ export interface APIResponse {
     utility: string | null;
   };
   location: APILocation;
-  savings: {
-    tax_credit: number;
-    pos_rebate: number;
-    rebate: number;
-    account_credit: number;
-  };
   incentives: Incentive[];
 }


### PR DESCRIPTION
## Description

To go with rewiringamerica/api.rewiringamerica.org#287.

The field was unused; this is just to make sure it stays that way.

## Test Plan

`yarn lint` to typecheck
