### PR TITLE
Add email-required attribute to calculator

### DIFF
--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -103,13 +103,16 @@ const renderProjectsField = (
 );
 
 const renderEmailField = (
+  emailRequired: boolean,
   email: string,
   setEmail: (e: string) => void,
   msg: MsgFn,
 ) => (
   <div>
     <FormLabel>
-      <label htmlFor="email">{msg('Email address (optional)')}</label>
+      <label htmlFor="email">
+        {emailRequired ? msg('Email address') : msg('Email address (optional)')}
+      </label>
     </FormLabel>
     <TextInput
       tabIndex={0}
@@ -122,6 +125,7 @@ const renderEmailField = (
       onChange={event => setEmail(event.currentTarget.value)}
       type="email"
       autoComplete="email"
+      required={emailRequired}
     />
     <div className="mt-1 mx-3 text-color-text-secondary text-xsm leading-normal">
       {msg(
@@ -154,10 +158,18 @@ export type FormValues = {
 export const CalculatorForm: FC<{
   initialValues: FormValues;
   showEmailField: boolean;
+  emailRequired: boolean;
   utilityFetcher: (zip: string) => Promise<APIUtilitiesResponse>;
   stateId?: string;
   onSubmit: (formValues: FormValues) => void;
-}> = ({ initialValues, showEmailField, utilityFetcher, stateId, onSubmit }) => {
+}> = ({
+  initialValues,
+  showEmailField,
+  emailRequired,
+  utilityFetcher,
+  stateId,
+  onSubmit,
+}) => {
   const { msg } = useTranslated();
 
   const [zip, setZip] = useState(initialValues.zip);
@@ -314,7 +326,9 @@ export const CalculatorForm: FC<{
           currentValue={householdSize}
           onChange={setHouseholdSize}
         />
-        {showEmailField ? renderEmailField(email, setEmail, msg) : null}
+        {showEmailField
+          ? renderEmailField(emailRequired, email, setEmail, msg)
+          : null}
         <div className="col-start-[-2] col-end-[-1]">
           <div className="h-0 sm:h-9"></div>
           <PrimaryButton id="calculate">{msg('Calculate')}</PrimaryButton>

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -109,6 +109,7 @@ const StateCalculator: FC<{
   attributeValues: FormValues;
   stateId?: string;
   showEmail: boolean;
+  emailRequired: boolean;
   includeBetaStates: boolean;
 }> = ({
   shadowRoot,
@@ -117,6 +118,7 @@ const StateCalculator: FC<{
   attributeValues,
   stateId,
   showEmail,
+  emailRequired,
   includeBetaStates,
 }) => {
   const { msg, locale } = useTranslated();
@@ -247,7 +249,8 @@ const StateCalculator: FC<{
           key={formKey}
           stateId={stateId}
           initialValues={getInitialFormValues()}
-          showEmailField={!!showEmail && !emailSubmitted}
+          showEmailField={showEmail && !emailSubmitted}
+          emailRequired={emailRequired}
           utilityFetcher={zip => {
             const query = new URLSearchParams({
               language: locale,
@@ -309,6 +312,13 @@ class CalculatorElement extends HTMLElement {
   /* property to show the email signup field */
   showEmail: boolean = false;
 
+  /**
+   * Property to require email when submitting the top-level form.
+   * Has no effect if the email field is not shown (whether because showEmail
+   * is false, or because an email has already been submitted).
+   */
+  emailRequired: boolean = false;
+
   /* property to include incentives from states that aren't formally launched */
   includeBetaStates: boolean = false;
 
@@ -330,6 +340,7 @@ class CalculatorElement extends HTMLElement {
   static observedAttributes = [
     'lang',
     'show-email',
+    'email-required',
     'include-beta-states',
     'api-key',
     'api-host',
@@ -383,6 +394,8 @@ class CalculatorElement extends HTMLElement {
       this.includeBetaStates = newValue !== null;
     } else if (attr === 'show-email') {
       this.showEmail = newValue !== null;
+    } else if (attr === 'email-required') {
+      this.emailRequired = newValue !== null;
     } else if (attr === 'state') {
       this.state = newValue ?? '';
     } else if (attr === 'zip') {
@@ -422,6 +435,7 @@ class CalculatorElement extends HTMLElement {
           }}
           stateId={this.state}
           showEmail={this.showEmail}
+          emailRequired={this.emailRequired}
           includeBetaStates={this.includeBetaStates}
         />
       </LocaleContext.Provider>,


### PR DESCRIPTION
## Description

A new boolean attribute that requires the email field in the top form
to be filled in if it's shown. (It already uses the browser's
validation for email address well-formedness.)

This has no effect on the mini email signup form that gets shown in
the empty-results state.

As far as I know currently, we don't need to send anything additional
to the email-signup endpoint; if it turns out we do, I'll do that as a
followup PR.

https://app.asana.com/0/1203194244067918/1206625793385634/f

## Test Plan

- Delete the `RA-calc-email-submitted` key from local storage if it's there.

- With neither `show-email` nor `email-required`, make sure you can submit the form.

- With only `show-email`, make sure you can submit the form without entering an email.

- With only `email-required`, make sure the email field is not shown and you can submit the form.

- With both, make sure the email field is shown, without the "(optional)" in the label, and trying to submit the form without an email results in a "please fill in this field" prompt from the browser, and the form isn't submitted.

- Fill in an email, and make sure the form submits and the email field disappears.

- Make sure the form is still submittable.
