### PR TITLE
Send email-required flag to signup endpoint

### DIFF
--- a/src/email-signup.ts
+++ b/src/email-signup.ts
@@ -17,6 +17,7 @@ export async function submitEmailSignup(
   apiKey: string,
   email: string,
   zip: string,
+  emailRequired: boolean,
 ): Promise<boolean> {
   safeLocalStorage.setItem(LOCAL_STORAGE_KEY, true);
 
@@ -26,7 +27,7 @@ export async function submitEmailSignup(
 
     const response = await fetch(url, {
       method: 'POST',
-      body: JSON.stringify({ email, zip }),
+      body: JSON.stringify({ email, zip, emailRequired }),
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -172,7 +172,7 @@ const StateCalculator: FC<{
 
     const email = formValues.email;
     if (email && !emailSubmitted) {
-      submitEmailSignup(apiHost, apiKey, email, formValues.zip);
+      submitEmailSignup(apiHost, apiKey, email, formValues.zip, emailRequired);
       // This hides the email field
       setEmailSubmitted(true);
     }
@@ -293,6 +293,7 @@ const StateCalculator: FC<{
                       apiKey,
                       email,
                       submittedFormValues!.zip,
+                      emailRequired,
                     );
                     setEmailSubmitted(true);
                   }


### PR DESCRIPTION
## Description

We'll want to track this along with signups to measure the effect of
requiring email. This will require a followup to Zuplo to read this
param and send it to SFMC.

## Test Plan

Sign up under both conditions, make sure the flag is present and with
the correct value in network inspector. (Zuplo isn't reading the flag
yet so nothing will change in SFMC.)