### PR TITLE
show partner logos in addition to authority logos

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -89,6 +89,16 @@ export interface APIResponse {
     state: string | null;
     utility: string | null;
   };
+  data_partners: {
+    [id: string]: {
+      name: string;
+      logo?: {
+        src: string;
+        width: number;
+        height: number;
+      };
+    };
+  };
   location: APILocation;
   incentives: Incentive[];
 }

--- a/src/partner-logos.tsx
+++ b/src/partner-logos.tsx
@@ -7,22 +7,26 @@ type Props = { response: APIResponse };
  * Displays the white area at the bottom of the calculator results with logos
  * of the authorities whose incentives are displayed.
  */
-export const AuthorityLogos = ({ response }: Props) => {
+export const PartnerLogos = ({ response }: Props) => {
   const { msg } = useTranslated();
   const authoritiesWithLogo = Object.entries(response.authorities).filter(
     ([, auth]) => !!auth.logo,
   );
-  if (authoritiesWithLogo.length === 0) {
+  const partnersWithLogo = Object.entries(response.data_partners).filter(
+    ([, partner]) => !!partner.logo,
+  );
+  const allLogos = [...authoritiesWithLogo, ...partnersWithLogo];
+  if (allLogos.length === 0) {
     return <></>;
   }
 
-  const logos = authoritiesWithLogo.map(([id, auth]) => (
+  const logos = allLogos.map(([id, partner]) => (
     <img
       key={id}
-      alt={auth.name}
-      src={auth.logo!.src}
-      width={auth.logo!.width}
-      height={auth.logo!.height}
+      alt={partner.name}
+      src={partner.logo!.src}
+      width={partner.logo!.width}
+      height={partner.logo!.height}
     />
   ));
 

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -7,7 +7,6 @@ import {
   Incentive,
   ItemType,
 } from './api/calculator-types-v1';
-import { AuthorityLogos } from './authority-logos';
 import { PrimaryButton, TextButton } from './buttons';
 import { Card } from './card';
 import { TextInput } from './components/text-input';
@@ -16,6 +15,7 @@ import { str } from './i18n/str';
 import { MsgFn, useTranslated } from './i18n/use-translated';
 import { IconTabBar } from './icon-tab-bar';
 import { ExclamationPoint, UpRightArrow } from './icons';
+import { PartnerLogos } from './partner-logos';
 import { PROJECTS, Project, shortLabel } from './projects';
 import { Separator } from './separator';
 
@@ -446,7 +446,7 @@ export const StateIncentives: FC<Props> = ({
         // We won't show the empty state in this seciton, so no email submission
         emailSubmitter={null}
       />
-      <AuthorityLogos response={response} />
+      <PartnerLogos response={response} />
     </>
   );
 };


### PR DESCRIPTION
⚠️ DO NOT MERGE: blocked by API changes. Also note that cypress test failures are expected until API code is merged

## Description

use new `data_partners` field to pull those logos and display them

## Test Plan

test locally with the API PR: https://github.com/rewiringamerica/api.rewiringamerica.org/pull/341
you should see the new logo