### PR TITLE
Use new "zip" param instead of "location[zip]"

### DIFF
--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -64,7 +64,7 @@ const fetch = (
   const query = new URLSearchParams({
     language,
     include_beta_states: '' + includeBetaStates,
-    'location[zip]': formValues.zip,
+    zip: formValues.zip,
     owner_status: formValues.ownerStatus,
     household_income: formValues.householdIncome,
     tax_filing: formValues.taxFiling,
@@ -255,7 +255,7 @@ const StateCalculator: FC<{
             const query = new URLSearchParams({
               language: locale,
               include_beta_states: '' + includeBetaStates,
-              'location[zip]': zip,
+              zip,
             });
 
             return fetchApi<APIUtilitiesResponse>(


### PR DESCRIPTION
## Description

The backend now has top-level params for zip and address instead of
the nested structure; it's generally friendlier to HTTP API tooling.

https://app.asana.com/0/1206661332626418/1206709967245555

## Test Plan

Cypress tests pass
