### PR TITLE
Add string to start_date and end_date types in v1

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -52,8 +52,8 @@ export interface Incentive {
   program_url?: string;
   item: Item;
   amount: Amount;
-  start_date: number;
-  end_date: number;
+  start_date: number | string;
+  end_date: number | string;
   short_description?: string;
 
   eligible: boolean;


### PR DESCRIPTION
## Description

This is in preparation for making these fields more expressive.

Somewhat amusingly, these fields are not actually used anywhere,
so this change has no downstream consequences. (`start_date` is used
in the old embed, but we're not concerned with that here.)

## Test Plan

`yarn lint` and Cypress pass.
