### PR TITLE
Make start and end date optional

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -52,8 +52,8 @@ export interface Incentive {
   program_url?: string;
   item: Item;
   amount: Amount;
-  start_date: number | string;
-  end_date: number | string;
+  start_date?: number | string;
+  end_date?: number | string;
   short_description?: string;
 
   eligible: boolean;


### PR DESCRIPTION
Most incentives don't have defined start and end dates (not that we
know, anyway), so requiring these fields has never really made
sense. The state calculator isn't using them, so this change has no
downstream effects.
