### PR TITLE
Fix the tax credit/rebate messaging on old embed

### DIFF
--- a/src/calculator.tsx
+++ b/src/calculator.tsx
@@ -21,11 +21,14 @@ import { tooltipStyles } from './tooltip';
 
 const loadedTemplate = (
   results: ICalculatedIncentiveResults,
+  ownerStatus: OwnerStatus,
   hideDetails: boolean,
   hideSummary: boolean,
 ) => (
   <>
-    {hideSummary ? null : <IncentiveSummary results={results} />}
+    {hideSummary ? null : (
+      <IncentiveSummary ownerStatus={ownerStatus} results={results} />
+    )}
     {hideDetails ? null : <IncentiveDetails results={results} />}
   </>
 );
@@ -183,7 +186,12 @@ export class RewiringAmericaCalculator extends LitElement {
           : this._task.render({
               pending: loadingTemplate,
               complete: results =>
-                loadedTemplate(results, this.hideDetails, this.hideSummary),
+                loadedTemplate(
+                  results,
+                  this.ownerStatus,
+                  this.hideDetails,
+                  this.hideSummary,
+                ),
               error: errorTemplate,
             })}
       </>

--- a/src/incentive-summary.tsx
+++ b/src/incentive-summary.tsx
@@ -1,6 +1,6 @@
 import { css } from 'lit';
 import { FC } from 'react';
-import { ICalculatedIncentiveResults } from './calculator-types';
+import { ICalculatedIncentiveResults, OwnerStatus } from './calculator-types';
 import { LightningBolt } from './icons';
 
 export const summaryStyles = css`
@@ -140,9 +140,10 @@ const upfrontDiscountLabel = ({
   }
 };
 
-export const IncentiveSummary: FC<{ results: ICalculatedIncentiveResults }> = ({
-  results,
-}) => (
+export const IncentiveSummary: FC<{
+  ownerStatus: OwnerStatus;
+  results: ICalculatedIncentiveResults;
+}> = ({ ownerStatus, results }) => (
   <div className="card">
     <div className="card__heading">
       <h1>Your Personalized Incentives</h1>
@@ -191,10 +192,29 @@ export const IncentiveSummary: FC<{ results: ICalculatedIncentiveResults }> = ({
           cannot guarantee final amounts or timeline.
         </p>
       </div>
-      {results.is_over_150_ami ? (
+      {results.tax_savings !== undefined &&
+      results.tax_savings <= 100 &&
+      ownerStatus === 'homeowner' ? (
         <div className="card__info">
           Based on your household income, you may not qualify for tax credits,
-          but you can take full advantage of the electrification rebates.
+          but you can take full advantage of the electrification rebates.{' '}
+          <a
+            href="https://content.rewiringamerica.org/reports/Rewiring%20America%20IRA%20Case%20Study%20-%20Modest%20Income.pdf"
+            target="_blank"
+          >
+            Check out this relevant case study!
+          </a>
+        </div>
+      ) : null}
+      {results.is_over_150_ami &&
+      ownerStatus === 'homeowner' &&
+      results.performance_rebate_savings ? (
+        <div className="card__info">
+          Your income is above the threshold for upfront discounts and/or EV tax
+          credits, but your tax liability will likely qualify you for equipment
+          tax credits. You do qualify for a performance-based efficiency rebate
+          worth ${results.performance_rebate_savings.toLocaleString()}. However,
+          we do not consider this an upfront discount.{' '}
           <a
             href="https://content.rewiringamerica.org/reports/Rewiring%20America%20IRA%20Case%20Study%20-%20High%20Income.pdf"
             target="_blank"


### PR DESCRIPTION
## Description

The old embed is not long for the world, but it's currently saying
some blatantly wrong things, so best fix them.

The text and conditions are copied from the old IRA calculator on the
main site. That frontend actually displays one other notice, only to
renters who are under 150% AMI. I'm not reproducing that here, again
because this frontend is on the way out, and it's not crucial info.

https://app.asana.com/0/1206661332626418/1206707343301439

## Test Plan

On the old embed, look up incentives for 80212 and $2000; make sure
the "you may not qualify for tax credits" message appears. Look up
incentives for 80252 and $200k; make sure the "your income is above
the threshold" message appears. Do $80k and make sure you get no
message (because you get tax savings and you're under 150% AMI).
