### PR TITLE
Use more_info_url from v1 API as link button destination

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -49,7 +49,9 @@ export interface Incentive {
   authority_type: AuthorityType;
   authority_name: string | null;
   program: string;
+  // TODO make program url required, stop using item.url
   program_url?: string;
+  more_info_url?: string;
   item: Item;
   amount: Amount;
   start_date?: number | string;

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -209,6 +209,17 @@ const LinkButton: FC<PropsWithChildren<{ href: string }>> = ({
 
 const IncentiveCard: FC<{ incentive: Incentive }> = ({ incentive }) => {
   const { msg } = useTranslated();
+  const [buttonUrl, buttonContent] = incentive.more_info_url
+    ? [incentive.more_info_url, msg('Learn more')]
+    : incentive.program_url
+    ? [
+        incentive.program_url,
+        <>
+          {msg('Visit site')}
+          <UpRightArrow w={20} h={20} />
+        </>,
+      ]
+    : [incentive.item.url, msg('Learn more')];
   return (
     <Card>
       <div className="flex flex-col gap-4 h-full">
@@ -229,10 +240,7 @@ const IncentiveCard: FC<{ incentive: Incentive }> = ({ incentive }) => {
             <Chip isWarning={true}>{msg('Expected in 2024')}</Chip>
           )
         }
-        <LinkButton href={incentive.program_url ?? incentive.item.url}>
-          {incentive.program_url ? msg('Visit site') : msg('Learn more')}
-          {incentive.program_url ? <UpRightArrow w={20} h={20} /> : null}
-        </LinkButton>
+        <LinkButton href={buttonUrl}>{buttonContent}</LinkButton>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Description

The links to the RA pages about the IRA incentives are currently in
`item.url`, which doesn't make conceptual sense. We're going to move
them to a new `more_info_url` field on incentives, and make
`program_url` required. We'll have

The backend is currently not sending `more_info_url` in v1 at all, so
this PR will be a no-op when it's deployed. After the backend change
is deployed, I'll follow up by removing `item.url` from the frontend,
and then from the backend.

## Test Plan

Run against the prod backend and make sure the IRA incentives have
link buttons with the same contents and URL as before.

Run against a local backend with the `more_info_url` change applied;
make sure the frontend continues to have exactly the same
behavior. (It used to be that the IRA incentives had no program URL,
so the buttons used the item URL. Now they do have a program URL, but
they all have a more-info URL that is exactly the same as the item
URL.)
