### PR TITLE
Stop using item.url; make program_url required

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -41,7 +41,6 @@ export type ItemType =
 export interface Item {
   type: ItemType;
   name: string;
-  url: string;
 }
 
 export interface Incentive {
@@ -49,8 +48,7 @@ export interface Incentive {
   authority_type: AuthorityType;
   authority_name: string | null;
   program: string;
-  // TODO make program url required, stop using item.url
-  program_url?: string;
+  program_url: string;
   more_info_url?: string;
   item: Item;
   amount: Amount;

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -211,15 +211,13 @@ const IncentiveCard: FC<{ incentive: Incentive }> = ({ incentive }) => {
   const { msg } = useTranslated();
   const [buttonUrl, buttonContent] = incentive.more_info_url
     ? [incentive.more_info_url, msg('Learn more')]
-    : incentive.program_url
-    ? [
+    : [
         incentive.program_url,
         <>
           {msg('Visit site')}
           <UpRightArrow w={20} h={20} />
         </>,
-      ]
-    : [incentive.item.url, msg('Learn more')];
+      ];
   const futureStartYear = getStartYearIfInFuture(incentive);
   return (
     <Card>


### PR DESCRIPTION
## Description

Followup to #150. This will let us remove item URLs from v1 if we want.

## Test Plan

This should be a no-op; the removed case should never be hit now that
program_url is required. Submit the form for a RI zip code and look at
HVAC incentives; make sure the non-IRA ones still say "visit site" and
the IRA ones say "learn more" and link to the homes.rewiring pages.
