### PR TITLE
Add disclaimer about residence location to city/county/other incentives

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -4,7 +4,13 @@ export type IncentiveType =
   | 'rebate'
   | 'account_credit'
   | 'performance_rebate';
-export type AuthorityType = 'federal' | 'state' | 'utility';
+export type AuthorityType =
+  | 'federal'
+  | 'state'
+  | 'utility'
+  | 'city'
+  | 'county'
+  | 'other';
 
 export type AmountType = 'dollar_amount' | 'percent' | 'dollars_per_unit';
 export type AmountUnit =

--- a/src/i18n/strings/es.ts
+++ b/src/i18n/strings/es.ts
@@ -85,6 +85,7 @@ export const templates = {
   s7a73c90a7c3b43b4: `un calentador de agua con bomba de calor`,
   s7bd0de02e230dc75: `Calentador de agua`,
   s7d340cf80adae3a4: `Misuri`,
+  s7f5b705d1bd02849: `La elegibilidad depende de la ubicación de residencia.`,
   s8194d17164cbd6de: `Florida`,
   s81aa671e64f2010e: `Dakota del Norte`,
   s82397872ac9bddcf: `Tamaño del hogar`,

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -219,6 +219,20 @@ const IncentiveCard: FC<{ incentive: Incentive }> = ({ incentive }) => {
         </>,
       ];
   const futureStartYear = getStartYearIfInFuture(incentive);
+
+  // The API cannot precisely tell, from zip code alone, whether the user is in
+  // a specific city or county; it takes a permissive approach and returns
+  // incentives for localities the user *might* be in. So this indicates that
+  // the user should check for themselves.
+  //
+  // This is a blunt-instrument approach; in many cases there's actually no
+  // ambiguity as to which city or county a zip code is in, but the API
+  // currently doesn't take that into account.
+  const locationEligibilityText = ['city', 'county', 'other'].includes(
+    incentive.authority_type,
+  )
+    ? msg('Eligibility depends on residence location.')
+    : null;
   return (
     <Card>
       <div className="flex flex-col gap-4 h-full">
@@ -231,7 +245,7 @@ const IncentiveCard: FC<{ incentive: Incentive }> = ({ incentive }) => {
         </div>
         <Separator hideOnSmall={true} />
         <div className="text-grey-400 leading-normal">
-          {incentive.short_description}
+          {incentive.short_description} {locationEligibilityText}
         </div>
         {futureStartYear && (
           <Chip isWarning={true}>

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -580,6 +580,10 @@
   <source>Expected in <x id="0" equiv-text="${futureStartYear}"/></source>
   <target>Esperado en <x id="0" equiv-text="${futureStartYear}"/></target>
 </trans-unit>
+<trans-unit id="s7f5b705d1bd02849">
+  <source>Eligibility depends on residence location.</source>
+  <target>La elegibilidad depende de la ubicación de residencia.</target>
+</trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
## Description

See the code comment for rationale. This is the simplest, bluntest
possible approach. Other possibilities are:

- Include the locality's name in this disclaimer message. This is not
  trivial to do because, although the API returns authority names,
  they're not necessarily suitable for interpolating into a
  sentence. E.g. Denver is named `City and County of Denver`, which
  does not work in an interpolation like `Limited to residents of
  ${name}`. (These names also aren't currently localized.)

  This approach also doesn't work for `other`-type incentives, because
  those authorities' names aren't place names.

- Have the API somehow indicate when a locality match is ambiguous,
  and only show the disclaimer in those cases. This would considerable
  work on the backend, to improve its simplistic mapping of zip to
  city and county name.

But given that we're imminently launching a state with local
incentives, I want to have something in place to cover this case.

The Spanish translation is from Google Translate, but I Googled the
phrase to confirm that very similar phrases are in wide use.

One final note: `other`-type incentives may be utility-based, not
locality-based, but the API doesn't convey that info.

## Test Plan

Search for HVAC incentives in 80212 to get some Denver incentives;
make sure the text shows up on the city incentives but not on others.
