### PR TITLE
Start supporting multi-valued "items" field

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -46,7 +46,6 @@ export type ItemType =
 
 export interface Item {
   type: ItemType;
-  name: string;
 }
 
 export interface Incentive {
@@ -56,7 +55,9 @@ export interface Incentive {
   program: string;
   program_url: string;
   more_info_url?: string;
+  // TODO when "items" backend change is deployed, remove "item"
   item: Item;
+  items?: ItemType[];
   amount: Amount;
   start_date?: string;
   end_date?: string;

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -36,7 +36,8 @@ const formatUnit = (unit: AmountUnit, msg: MsgFn) =>
     : unit;
 
 const formatTitle = (incentive: Incentive, msg: MsgFn) => {
-  const item = itemName(incentive.item.type, msg);
+  const itemValue = incentive.items ? incentive.items[0] : incentive.item.type;
+  const item = itemName(itemValue, msg);
   const amount = incentive.amount;
   if (amount.type === 'dollar_amount') {
     return amount.maximum
@@ -421,9 +422,11 @@ export const StateIncentives: FC<Props> = ({
   const allEligible = response.incentives.filter(i => i.eligible);
 
   const incentivesByProject = Object.fromEntries(
-    Object.entries(PROJECTS).map(([project, info]) => [
+    Object.entries(PROJECTS).map(([project, projectInfo]) => [
       project,
-      allEligible.filter(i => info.items.includes(i.item.type)),
+      allEligible.filter(i =>
+        projectInfo.items.includes(i.items ? i.items[0] : i.item.type),
+      ),
     ]),
   ) as Record<Project, Incentive[]>;
 


### PR DESCRIPTION
## Description

In preparation for rolling out more granular `item` values for things
like heat pumps and weatherization, incentives will need to support
multiple values items. This change starts reading from a new
array-valued `items` field if it's available.

Next step will be to deploy a backend change that adds the
multi-valued field to responses. Then, remove `item` from the
frontend. Then, remove `item` from the backend.

https://app.asana.com/0/1206661332626418/1206911030685282

## Test Plan

Running calculations against a local backend that has the `items`
change applied succeeds; Cypress tests pass in that state.
