### PR TITLE
Bump the local storage key for saved form values

### DIFF
--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -29,7 +29,11 @@ const DEFAULT_HOUSEHOLD_INCOME = '0';
 const DEFAULT_HOUSEHOLD_SIZE = '1';
 const DEFAULT_UTILITY = '';
 
-const FORM_VALUES_LOCAL_STORAGE_KEY = 'RA-calc-form-values';
+/**
+ * If you make a backward-incompatible change to the format of form value
+ * storage, increment the version in this key.
+ */
+const FORM_VALUES_LOCAL_STORAGE_KEY = 'RA-calc-form-values-v2';
 declare module './safe-local-storage' {
   interface SafeLocalStorageMap {
     [FORM_VALUES_LOCAL_STORAGE_KEY]: Partial<FormValues>;


### PR DESCRIPTION
## Description

In #158 I changed the constants that identify projects. I didn't
realize this would break the calculator for users who had the old
constants in local storage (as saved form values).

This is the simplest solution: change the local storage key for saved
form values, which will effectively clear the stored values for
everyone, one time.

There's no attempt to migrate the old values. We would have to support
that code indefinitely (unless we eventually cleared storage anyway),
and I don't think there's a ton of value in preserving form prefills.

The old key will still be there in users' local storage; if we want,
we can follow up with a change to delete it.

## Test Plan

Before making this change, reproed the problem by manually editing
local storage and changing the `RA-calc-form-values` value to have the
old constant `heat_pump_clothes_dryer` in the `projects` field. Submit
the form and make sure there was an error (trying to read `shortLabel`
of `undefined`).

Apply this change, make sure the form is reset to defaults, and
submitting it doesn't cause an error, and results show up.
