### PR TITLE
Remove deprecated v1 items

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -59,11 +59,11 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('$1,000/ton off a heat pump');
+      .contains('$1,000/ton off an air source heat pump');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('$350/ton off a heat pump');
+      .contains('$350/ton off a ducted heat pump');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
@@ -71,7 +71,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('$2,000 off a heat pump');
+      .contains('$2,000 off an air source heat pump');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()

--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -49,7 +49,6 @@ export const ITEMS = [
   'energy_audit',
   'floor_insulation',
   'geothermal_heating_installation',
-  'heat_pump_air_conditioner_heater',
   'heat_pump_clothes_dryer',
   'heat_pump_water_heater',
   'new_electric_vehicle',
@@ -63,7 +62,6 @@ export const ITEMS = [
   'used_electric_vehicle',
   'used_plugin_hybrid_vehicle',
   'wall_insulation',
-  'weatherization',
   'window_replacement',
 ] as const;
 

--- a/src/item-name.ts
+++ b/src/item-name.ts
@@ -30,7 +30,6 @@ const ALL_WEATHERIZATION: ItemType[] = [
   'door_replacement',
   'duct_replacement',
   'duct_sealing',
-  'weatherization',
   'window_replacement',
   'efficiency_rebates',
   'other_weatherization',
@@ -250,8 +249,6 @@ export const itemName = (items: ItemType[], msg: MsgFn) => {
       return msg('geothermal heating installation', {
         desc: 'e.g. "$100 off [this string]"',
       });
-    case 'heat_pump_air_conditioner_heater':
-      return msg('a heat pump', { desc: 'e.g. "$100 off [this string]"' });
     case 'heat_pump_clothes_dryer':
       return msg('a heat pump clothes dryer', {
         desc: 'e.g. "$100 off [this string]"',
@@ -294,8 +291,6 @@ export const itemName = (items: ItemType[], msg: MsgFn) => {
       });
     case 'wall_insulation':
       return msg('wall insulation', { desc: 'e.g. "$100 off [this string]"' });
-    case 'weatherization':
-      return msg('weatherization', { desc: 'e.g. "$100 off [this string]"' });
     case 'window_replacement':
       return msg('window replacement', {
         desc: 'e.g. "$100 off [this string]"',

--- a/src/projects.tsx
+++ b/src/projects.tsx
@@ -51,7 +51,6 @@ export const PROJECTS: Record<Project, ProjectInfo> = {
       'ductless_heat_pump',
       'geothermal_heating_installation',
       'other_heat_pump',
-      'heat_pump_air_conditioner_heater',
     ],
     label: msg => msg('Heating, ventilation & cooling'),
     shortLabel: msg =>
@@ -113,7 +112,6 @@ export const PROJECTS: Record<Project, ProjectInfo> = {
       'duct_sealing',
       'floor_insulation',
       'wall_insulation',
-      'weatherization',
       'window_replacement',
       'efficiency_rebates',
       'other_insulation',


### PR DESCRIPTION
## Description

The backend is about to stop supporting these items, so don't send them up.

## Test Plan

Ran against local backend with and without the change that removes
these items; make sure the results are the same (for HVAC and
weatherization projects) in both cases, and there are no errors.
