### PR TITLE
Prepare for the API to drop eligible flag

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -80,7 +80,7 @@ export interface Incentive {
   end_date?: string;
   short_description?: string;
 
-  eligible: boolean;
+  eligible?: boolean;
 }
 
 export interface APILocation {

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -439,7 +439,9 @@ export const StateIncentives: FC<Props> = ({
 
   // We're filtering out IRA rebates in favor of state-specific handling.
   const allEligible = response.incentives
-    .filter(i => i.eligible)
+    // Forward compatibility for when only eligible incentives are returned from
+    // the API, with no eligible flag.
+    .filter(i => i.eligible === true || i.eligible === undefined)
     .filter(i => !isIRARebate(i));
 
   // Map each project to all incentives that involve it. An incentive may


### PR DESCRIPTION
## Description

We're going to have the v1 API only return eligible incentives, then
drop the eligible flag. This prepares the frontend for that change.

https://app.asana.com/0/1206604760097762/1207354145545391

## Test Plan

Query for EV incentives in Rhode Island (02861) with a 20k income and
a 200k income.

- In the former case, make sure there are DRIVE+ incentives
  (low-income only) shown.

- In the latter case, make sure they're not shown. Look in Network
  Inspector to make sure they were actually returned from the API,
  with `eligible: false`.
