### PR TITLE
Don't pass the include_beta_states flag to /v1/utilities

### DIFF
--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -256,11 +256,7 @@ const StateCalculator: FC<{
           showEmailField={showEmail && !emailSubmitted}
           emailRequired={emailRequired}
           utilityFetcher={zip => {
-            const query = new URLSearchParams({
-              language: locale,
-              include_beta_states: '' + includeBetaStates,
-              zip,
-            });
+            const query = new URLSearchParams({ language: locale, zip });
 
             return fetchApi<APIUtilitiesResponse>(
               apiKey,


### PR DESCRIPTION
## Description

It's not used anymore since we started returning utilities for all locations.

## Test Plan

Fill in the zip field with 94306 (CA, a non-launched state) and make
sure it returns results.
