### PR TITLE
Add ra_embed query param

### DIFF
--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -82,6 +82,7 @@ const fetch = (
       query.append('items', item);
     });
   });
+  // Tracking usage of the embedded calculator
   query.append('ra_embed', '1');
 
   return fetchApi<APIResponse>(
@@ -258,6 +259,8 @@ const StateCalculator: FC<{
           emailRequired={emailRequired}
           utilityFetcher={zip => {
             const query = new URLSearchParams({ language: locale, zip });
+            // Tracking usage of the embedded calculator
+            query.append('ra_embed', '1');
 
             return fetchApi<APIUtilitiesResponse>(
               apiKey,

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -82,6 +82,7 @@ const fetch = (
       query.append('items', item);
     });
   });
+  query.append('ra_embed', '1');
 
   return fetchApi<APIResponse>(
     apiKey,


### PR DESCRIPTION
## Description

Add a new `ra_embed` query param to the embedded calculator API calls.

## Test Plan
I tested this locally and used the Chrome developer tools to confirm that the new query param is being sent. I then went into BigQuery and was able to successfully pull records where `ra_embed = 1`.
