### PR TITLE
Expose CSS variable for calculator font

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -62,10 +62,10 @@
   color: black;
   font-smoothing: antialiased;
   -webkit-font-smoothing: antialiased;
-  font-family: 'GT America', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
-    'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family: var(--font-family), 'GT America', system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-size: 16px;
   line-height: 28px;
   font-weight: 400;


### PR DESCRIPTION
## Description

You can define `--font-family` in the surrounding page to customize
the calculator's font. It falls back to the calculator's existing
series of fonts.

## Test Plan

In index.html, add this to the CSS in the head tag:

```css
#calculator {
  --font-family: 'comic sans ms';
}
```
