### PR TITLE
Exclude HER rebates for Maine

### DIFF
--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -60,7 +60,7 @@ const hearRebates: {
  * generic info to users in those states.
  */
 const HEAR_EXCLUDE_STATES = new Set(['NY']);
-const HER_EXCLUDE_STATES = new Set(['WI']);
+const HER_EXCLUDE_STATES = new Set(['ME', 'WI']);
 
 export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
   const disclaimerText = msg(


### PR DESCRIPTION
Do not merge until https://github.com/rewiringamerica/api.rewiringamerica.org/pull/579 is released

- [Asana ticket](https://app.asana.com/0/1207456219977120/1208308155636485/f)

## Description

We received information from Efficiency Maine that HER rebates are going to be used solely for multifamily properties and therefore, details should not be displayed for HER rebates.

## Test Plan

- look up any Maine-based zip code (e.g. 04101)
- ensure that the generic HER card isn't appearing