### PR TITLE
Exclude RI HEAR Rebates

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -61,7 +61,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('Discount off a heat pump');
+      .contains('Up to $1,840 off a heat pump'); // Reflects RI's HEAR implementation
 
     cy.get('rewiring-america-state-calculator')
       .shadow()

--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -61,10 +61,6 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('Up to $1,840 off a heat pump'); // Reflects RI's HEAR implementation
-
-    cy.get('rewiring-america-state-calculator')
-      .shadow()
       .contains('$1,000/ton off an air source heat pump');
 
     cy.get('rewiring-america-state-calculator')

--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -59,7 +59,7 @@ const hearRebates: {
  * As states launch their HEAR and HER programs, we'll want to stop showing this
  * generic info to users in those states.
  */
-const HEAR_EXCLUDE_STATES = new Set(['NY']);
+const HEAR_EXCLUDE_STATES = new Set(['NY', 'RI']);
 const HER_EXCLUDE_STATES = new Set(['ME', 'WI']);
 
 export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {


### PR DESCRIPTION
Do not merge until https://github.com/rewiringamerica/api.rewiringamerica.org/pull/580 is released

## Description

Now that RI has rolled out their HEAR rebates and we've incorporated them into the API ([here](https://github.com/rewiringamerica/api.rewiringamerica.org/pull/580)), we should hide the generic HEAR card

## Test Plan

- look up any RI-based zip code (e.g. 02903)
- ensure that the generic HEAR card isn't appearing