### PR TITLE
Update item name feature to handle HEAR rebate projects

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -88,6 +88,12 @@ describe('rewiring-america-state-calculator', () => {
       .checkA11y(null, {
         runOnly: ['wcag2a', 'wcag2aa'],
       });
+
+    cy.selectProjects(['cooking']);
+
+    cy.get('rewiring-america-state-calculator')
+      .shadow()
+      .contains('Up to $1,840 off an electric/induction stove');
   });
 
   it('shows an error if you query in the wrong state', () => {

--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -93,7 +93,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('Up to $1,840 off an electric/induction stove');
+      .contains('Up to $420 off an electric/induction stove');
   });
 
   it('shows an error if you query in the wrong state', () => {

--- a/src/item-name.ts
+++ b/src/item-name.ts
@@ -198,18 +198,22 @@ const hearName = (items: ItemType[], msg: MsgFn, project: Project) => {
   const HEAR_INCENTIVE_PROJECT_MSG_LIST: {
     item: ItemType;
     project: Project;
-    itemName: string;
+    msg: string;
   }[] = [
     {
       item: 'heat_pump_clothes_dryer',
       project: 'clothes_dryer',
-      itemName: 'a heat pump clothes dryer',
+      msg: msg('a heat pump clothes dryer', {
+        desc: 'e.g. "$100 off [this string]"',
+      }),
     },
 
     {
       item: 'electric_stove',
       project: 'cooking',
-      itemName: 'an electric/induction stove',
+      msg: msg('an electric/induction stove', {
+        desc: 'e.g. "$100 off [this string]"',
+      }),
     },
   ];
 
@@ -219,7 +223,7 @@ const hearName = (items: ItemType[], msg: MsgFn, project: Project) => {
 
   if (!match) return null;
 
-  return msg(match.itemName, { desc: 'e.g. "$100 off [this string]"' });
+  return match.msg;
 };
 
 /**

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -33,8 +33,8 @@ const formatUnit = (unit: AmountUnit, msg: MsgFn) =>
     ? msg('watt')
     : unit;
 
-const formatTitle = (incentive: Incentive, msg: MsgFn) => {
-  const item = itemName(incentive.items, msg);
+const formatTitle = (incentive: Incentive, msg: MsgFn, project: Project) => {
+  const item = itemName(incentive.items, msg, project);
   if (!item) {
     return null;
   }
@@ -145,6 +145,7 @@ const renderCardCollection = (
   incentives: Incentive[],
   iraRebates: IRARebate[],
   showComingSoon: boolean,
+  project: Project,
 ) => {
   const { msg } = useTranslated();
   return (
@@ -156,7 +157,7 @@ const renderCardCollection = (
             (getStartYearIfInFuture(a) ?? 0) - (getStartYearIfInFuture(b) ?? 0),
         )
         .map((incentive, index) => {
-          const headline = formatTitle(incentive, msg);
+          const headline = formatTitle(incentive, msg, project);
           if (!headline) {
             // We couldn't generate a headline either because the items are
             // unknown, or the amount type is unknown. Don't show a card.
@@ -271,7 +272,12 @@ const IncentiveGrid = forwardRef<HTMLDivElement, IncentiveGridProps>(
           />
         </div>
         {selectedTab !== null
-          ? renderCardCollection(incentives, iraRebates, !hasStateCoverage)
+          ? renderCardCollection(
+              incentives,
+              iraRebates,
+              !hasStateCoverage,
+              selectedTab,
+            )
           : renderSelectProjectCard()}
       </>
     );

--- a/test/item-names.test.ts
+++ b/test/item-names.test.ts
@@ -4,47 +4,80 @@ import { itemName } from '../src/item-name';
 
 describe('group names', () => {
   test('heat pumps', () => {
-    expect(itemName(['ducted_heat_pump', 'ductless_heat_pump'], msg)).toBe(
-      'an air source heat pump',
-    );
     expect(
-      itemName(['ducted_heat_pump', 'geothermal_heating_installation'], msg),
+      itemName(['ducted_heat_pump', 'ductless_heat_pump'], msg, 'hvac'),
+    ).toBe('an air source heat pump');
+    expect(
+      itemName(
+        ['ducted_heat_pump', 'geothermal_heating_installation'],
+        msg,
+        'hvac',
+      ),
     ).toBe('a heat pump');
   });
 
   test('weatherization and insulation', () => {
     expect(
-      itemName(['attic_or_roof_insulation', 'basement_insulation'], msg),
+      itemName(
+        ['attic_or_roof_insulation', 'basement_insulation'],
+        msg,
+        'weatherization_and_efficiency',
+      ),
     ).toBe('insulation');
-    expect(itemName(['attic_or_roof_insulation', 'air_sealing'], msg)).toBe(
-      'weatherization',
-    );
-    expect(itemName(['wall_insulation', 'other_insulation'], msg)).toBe(
-      'insulation',
-    );
-    expect(itemName(['wall_insulation', 'other_weatherization'], msg)).toBe(
-      'weatherization',
-    );
-    expect(itemName(['other_weatherization', 'energy_audit'], msg)).toBe(
-      'an energy audit and weatherization',
-    );
+    expect(
+      itemName(
+        ['attic_or_roof_insulation', 'air_sealing'],
+        msg,
+        'weatherization_and_efficiency',
+      ),
+    ).toBe('weatherization');
+    expect(
+      itemName(
+        ['wall_insulation', 'other_insulation'],
+        msg,
+        'weatherization_and_efficiency',
+      ),
+    ).toBe('insulation');
+    expect(
+      itemName(
+        ['wall_insulation', 'other_weatherization'],
+        msg,
+        'weatherization_and_efficiency',
+      ),
+    ).toBe('weatherization');
+    expect(
+      itemName(
+        ['other_weatherization', 'energy_audit'],
+        msg,
+        'weatherization_and_efficiency',
+      ),
+    ).toBe('an energy audit and weatherization');
   });
 
   test('vehicles', () => {
     expect(
-      itemName(['new_electric_vehicle', 'used_electric_vehicle'], msg),
+      itemName(['new_electric_vehicle', 'used_electric_vehicle'], msg, 'ev'),
     ).toBe('an electric vehicle');
     expect(
       itemName(
         ['new_plugin_hybrid_vehicle', 'used_plugin_hybrid_vehicle'],
         msg,
+        'ev',
       ),
     ).toBe('a plug-in hybrid');
     expect(
-      itemName(['new_electric_vehicle', 'new_plugin_hybrid_vehicle'], msg),
+      itemName(
+        ['new_electric_vehicle', 'new_plugin_hybrid_vehicle'],
+        msg,
+        'ev',
+      ),
     ).toBe('a new vehicle');
     expect(
-      itemName(['used_electric_vehicle', 'used_plugin_hybrid_vehicle'], msg),
+      itemName(
+        ['used_electric_vehicle', 'used_plugin_hybrid_vehicle'],
+        msg,
+        'ev',
+      ),
     ).toBe('a used vehicle');
 
     expect(
@@ -56,7 +89,22 @@ describe('group names', () => {
           'used_plugin_hybrid_vehicle',
         ],
         msg,
+        'ev',
       ),
     ).toBeNull();
+  });
+
+  test('HEAR rebates applicable to multiple appliances', () => {
+    expect(
+      itemName(['heat_pump_clothes_dryer', 'electric_stove'], msg, 'cooking'),
+    ).toBe('an electric/induction stove');
+
+    expect(
+      itemName(
+        ['heat_pump_clothes_dryer', 'electric_stove'],
+        msg,
+        'clothes_dryer',
+      ),
+    ).toBe('a heat pump clothes dryer');
   });
 });


### PR DESCRIPTION
## Description

This fixes an issue in which HEAR rebate cards weren't showing up when the technologies they applied to were considered to be in multiple project categories, i.e. Rhode Island's rebates being applicable to stoves and clothes dryers

## Test Plan

Zip code: 02903; hhsize 1, income 30000

![Screenshot 2024-09-20 at 3 59 30 PM](https://github.com/user-attachments/assets/0c30c199-bc7e-46c2-99a5-94ad0e5a0e9f)
![Screenshot 2024-09-20 at 3 59 43 PM](https://github.com/user-attachments/assets/a8ece193-509d-45d0-93d7-c701b076f393)
