### PR TITLE
Add gas utility selector

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -98,6 +98,7 @@ export interface APIUtilityMap {
 export interface APIUtilitiesResponse {
   location: APILocation;
   utilities: APIUtilityMap;
+  gas_utilities?: APIUtilityMap;
 }
 
 export interface APIResponse {

--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -99,6 +99,7 @@ export interface APIUtilitiesResponse {
   location: APILocation;
   utilities: APIUtilityMap;
   gas_utilities?: APIUtilityMap;
+  gas_utility_affects_incentives?: boolean;
 }
 
 export interface APIResponse {

--- a/src/api/fetch-state.ts
+++ b/src/api/fetch-state.ts
@@ -4,6 +4,11 @@ export type FetchState<T> =
     }
   | {
       state: 'loading';
+      /**
+       * If the previous state was loading, this may or may not contain the
+       * response value from that state.
+       */
+      previousResponse?: T;
     }
   | {
       state: 'complete';

--- a/src/i18n/strings/es.ts
+++ b/src/i18n/strings/es.ts
@@ -137,6 +137,7 @@ export const templates = {
   sa9e16de0ec0154b3: `aire acondicionado central`,
   saa36bebd89cbd670: `Alaska`,
   sab07cf2bfae8483f: `Política de privacidad`,
+  sab68e846cf3e7e02: `Empresa de gas`,
   sab856460d5aed19e: `equipo eléctrico para exteriores`,
   sabd5662f3f0a76be: `Descuento por adelantado`,
   sad181d4343ef967f: `Wyoming`,
@@ -170,6 +171,7 @@ export const templates = {
   sc2e0d466583b17f8: `aislamiento del entrepiso`,
   sc5b20cb72269bc4f: `Los propietarios y inquilinos califican para diferentes incentivos.`,
   sc9266b1b6ae1aad4: `Esperado en 2024-2025`,
+  sc967ff75e8a58273: `Selecciona la empresa a la que paga su factura de gas.`,
   sc991c5ecbb3023ef: `aislamiento térmico`,
   sc997cfdf24ba9b58: `Aún no tenemos datos sobre las empresas de servicios eléctricos en su área.`,
   sc9e494c8346b7cb5: `Otra`,
@@ -204,4 +206,6 @@ export const templates = {
   sfa7338035e1ef173: `Alquilar o poseer`,
   sfc7214f623fe475d: `Selecciona la empresa a la que paga su factura de electricidad.`,
   sfe16afc784bb9d76: `Techo solar`,
+  sb2d056e8d2ea5bc5: `Delivered propane or fuel oil`,
+  s52d768131ca697d4: `No gas service`,
 };

--- a/src/i18n/strings/es.ts
+++ b/src/i18n/strings/es.ts
@@ -76,6 +76,7 @@ export const templates = {
   s50c22fc6197c004a: `un vehículo nuevo`,
   s50e95c2064db3522: `Calculadora por`,
   s52ca6c8b262e0183: `y recibir actualizaciones de Rewiring America.`,
+  s52d768131ca697d4: `Sin servicio de gas`,
   s56f9b2194465973e: `tonelada`,
   s57355ce02837df3c: `Illinois`,
   s579f082fddf5ad2d: `una bicicleta eléctrica`,
@@ -150,6 +151,7 @@ export const templates = {
   sb04b1070af7f7b76: `Washington, DC`,
   sb1b20a59970ba607: `Incluye a cualquier persona con la que viva y que reclame como dependiente en sus impuestos, y a su cónyuge o pareja si presenta impuestos conjuntos.`,
   sb1ef6ac20f1ddfff: `Descuento en un tablero eléctrico`,
+  sb2d056e8d2ea5bc5: `Propano o fueloil entregado`,
   sb3615709fedc9d4d: `Reembolsos para la Electrificación del Hogar y Electrodomésticos (HEAR)`,
   sb5b955a693af9c2e: `Virginia`,
   sb661e8297dd681e2: `Incentivo`,
@@ -206,6 +208,4 @@ export const templates = {
   sfa7338035e1ef173: `Alquilar o poseer`,
   sfc7214f623fe475d: `Selecciona la empresa a la que paga su factura de electricidad.`,
   sfe16afc784bb9d76: `Techo solar`,
-  sb2d056e8d2ea5bc5: `Delivered propane or fuel oil`,
-  s52d768131ca697d4: `No gas service`,
 };

--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -87,20 +87,20 @@ const renderUtilityFields = (
   );
 
   let gasSelector = null;
-  const gasUtilities =
+  const gasResponse =
     utilitiesFetch.state === 'complete'
-      ? utilitiesFetch.response.gas_utilities
+      ? utilitiesFetch.response
       : utilitiesFetch.state === 'loading'
-      ? utilitiesFetch.previousResponse?.gas_utilities
+      ? utilitiesFetch.previousResponse
       : null;
 
-  // If the response does not contain the gas utilities key, that means the
-  // user's gas utility is irrelevant, so we don't show the selector. If the key
-  // is present, we need to show the selector even if the gas utilities map is
-  // empty, because it matters whether the user actually has no gas service, or
-  // has gas service that's not listed here (indicated by the Other item).
-  if (gasUtilities) {
-    const gasOptions = Object.entries(gasUtilities)
+  // Show the gas utility selector if and only if the choice is relevant to
+  // incentive eligibility. Even if the map of gas utilities is empty, we need
+  // to show the selector to allow the user to distinguish between actually
+  // having no gas service, and having gas service that's not listed here
+  // (indicated by the Other item).
+  if (gasResponse?.gas_utility_affects_incentives) {
+    const gasOptions = Object.entries(gasResponse.gas_utilities || {})
       .map(([id, info]) => ({ value: id, label: info.name }))
       .concat([
         {

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -75,6 +75,9 @@ const fetch = (
   if (formValues.utility) {
     query.set('utility', formValues.utility);
   }
+  if (formValues.gasUtility) {
+    query.set('gas_utility', formValues.gasUtility);
+  }
   Object.values(PROJECTS).forEach(project => {
     project.items.forEach(item => {
       query.append('items', item);

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -786,6 +786,21 @@
   <source>privacy policy</source>
   <target>política de privacidad</target>
 </trans-unit>
+<trans-unit id="sb2d056e8d2ea5bc5">
+  <source>Delivered propane or fuel oil</source>
+</trans-unit>
+<trans-unit id="s52d768131ca697d4">
+  <source>No gas service</source>
+</trans-unit>
+<trans-unit id="sc967ff75e8a58273">
+  <source>Choose the company you pay your gas bill to.</source>
+  <target>Selecciona la empresa a la que paga su factura de gas.</target>
+</trans-unit>
+<trans-unit id="sab68e846cf3e7e02">
+  <source>Gas Utility</source>
+  <target>Empresa de gas</target>
+  <note from="lit-localize">as in utility company</note>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -788,9 +788,11 @@
 </trans-unit>
 <trans-unit id="sb2d056e8d2ea5bc5">
   <source>Delivered propane or fuel oil</source>
+  <target>Propano o fueloil entregado</target>
 </trans-unit>
 <trans-unit id="s52d768131ca697d4">
   <source>No gas service</source>
+  <target>Sin servicio de gas</target>
 </trans-unit>
 <trans-unit id="sc967ff75e8a58273">
   <source>Choose the company you pay your gas bill to.</source>


### PR DESCRIPTION
## Links

- https://app.asana.com/0/1208668890181682/1208886892124341

## Description

- Show the gas utility selector if the `/utilities` call says that
  the choice is relevant to incentive eligibility. Even if there
  are no gas utilities, we still show the selector to offer the
  choice of "no gas service" vs. "other", which is significant in the
  Mass Save case.

- The selector always has three items at the bottom, after any real
  utilities: "Delivered propane or fuel oil", "No gas service", and
  "Other". The former two behave exactly the same behind the scenes,
  but are intended to reduce confusion: users may not know that we
  mean natural/methane gas pipeline service when we say "gas service"
  or "gas utility".

- I had to add the `previousResponse` field to FetchState's loading
  state, so that the gas utility selector can stay visible and
  populated if you enter a new zip code. Otherwise, the selector would
  disappear while the `/utilities` call was pending, and it would look
  janky.

As implemented, when you enter a zip code in MA and the `/utilities`
call completes, the gas utility selector just pops in. This is pretty
disruptive to the rest of the form in the two-column view, because all
the other fields reposition --- they're in the same tabbing order, but
ones that were on the left are now on the right and vice versa. It's
not so bad in one-column view. I think this is tolerable for now,
especially since the selector will only appear for MA zip codes. But
it may be worth a rethink.

## Test Plan

Add `api-host` attribute to the element on index.html to hit my local
API server (so gas utilities are returned).

Enter zip codes in MA to see the gas selector pop in, and make sure
the options make sense. E.g. 02130 (Boston; has Eversource) and 01011
(middle of nowhere; has no gas).

Enter one MA zip code, then another; make sure the gas selector stays
visible throughout. Then enter a non-MA zip code; make sure the
selector disappears once the new location's electric utilities are
populated.

Submit the form with the various gas options selected. Use network
inspector to check the `gas_utility` param sent to the API. (Currently
the API's response won't change based on it.) It should be `none` if
"delivered fuels" or "no gas service" is selected, absent if "other"
is selected, and a utility ID if a real gas utility is selected.
