### PR TITLE
Exclude GA HEAR/HER and NY HER default cards

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -61,7 +61,7 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('$1,000/ton off an air source heat pump');
+      .contains('$750/ton off an air source heat pump');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -213,7 +213,7 @@ export const Select = <T extends string>({
                 {o.getIcon && (
                   <span className="text-lg text-grey-700">{o.getIcon()}</span>
                 )}
-                <span className="grow">{o.label}</span>
+                <span className="grow text-color-text-primary">{o.label}</span>
                 {o.badge !== undefined && <Badge num={o.badge} />}
               </Listbox.Option>
             ))}

--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -60,7 +60,7 @@ const hearRebates: {
  * generic info to users in those states.
  */
 const HEAR_EXCLUDE_STATES = new Set(['DC', 'ME', 'NY', 'RI']);
-const HER_EXCLUDE_STATES = new Set(['DC', 'ME', 'WI']);
+const HER_EXCLUDE_STATES = new Set(['DC', 'ME', 'NY', 'WI']);
 
 export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
   const disclaimerText = msg(

--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -59,8 +59,8 @@ const hearRebates: {
  * As states launch their HEAR and HER programs, we'll want to stop showing this
  * generic info to users in those states.
  */
-const HEAR_EXCLUDE_STATES = new Set(['DC', 'ME', 'NY', 'RI']);
-const HER_EXCLUDE_STATES = new Set(['DC', 'ME', 'NY', 'WI']);
+const HEAR_EXCLUDE_STATES = new Set(['DC', 'GA', 'ME', 'NY', 'RI']);
+const HER_EXCLUDE_STATES = new Set(['DC', 'GA', 'ME', 'NY', 'WI']);
 
 export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
   const disclaimerText = msg(


### PR DESCRIPTION
## Description

- Exclude GA HEAR/HER "Expected in" cards
- Exclude NY HER card

This PR also fixes an a11y violation for color contrast that Cypress was mistakenly catching while the project type dropdown was loading. I'm not sure why it appears to only happen on PRs that remove generic HEAR/HER cards (e.g. [this other PR for NY](https://github.com/rewiringamerica/embed.rewiringamerica.org/pull/195#issuecomment-2503943755))

## Test Plan

Check zip codes in NY (10001) and GA (30030) to ensure that the HEAR/HER "Expected in" cards aren't visible