### PR TITLE
Include beta states by default

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -59,18 +59,19 @@ describe('rewiring-america-state-calculator', () => {
 
     cy.selectProjects(['hvac']);
 
+    // RI Energy incentive
+    // Note: if there are no RI-specific HVAC incentives left,
+    // please switch this test case to another state!
     cy.get('rewiring-america-state-calculator')
       .shadow()
       .contains('$750/ton off an air source heat pump');
 
-    cy.get('rewiring-america-state-calculator')
-      .shadow()
-      .contains('$350/ton off a ducted heat pump');
-
+    // 25D
     cy.get('rewiring-america-state-calculator')
       .shadow()
       .contains('30% of cost of geothermal heating installation');
 
+    // 25C
     cy.get('rewiring-america-state-calculator')
       .shadow()
       .contains('$2,000 off an air source heat pump');

--- a/src/index.html
+++ b/src/index.html
@@ -78,6 +78,7 @@
           type="checkbox"
           id="includeBeta"
           onChange="this.checked ? document.getElementById('calculator').setAttribute('include-beta-states', '') : document.getElementById('calculator').removeAttribute('include-beta-states')"
+          checked
         />
         <label for="includeBeta">
           Include incentives from states that are not yet ready for full launch.
@@ -93,6 +94,7 @@
         household-size="1"
         tax-filing="single"
         owner-status="homeowner"
+        include-beta-states
       ></rewiring-america-state-calculator>
     </main>
   </body>


### PR DESCRIPTION
## Description

People using the embed seem to forget to enable the beta state option fairly often. Let's set it to be on by default since the main use of this page is testing the calculator with pre-release data.

## Test Plan

Load the preview build and verify that the beta checkbox is selected and that `include-beta-states` is set on the embed element. Ensure that `include_beta_states` is passed to the API when you submit the calculator. Disable the checkbox and verify that `include-beta-states` is removed from the widget and that `include_beta_states` is not set when you submit the calculator.