### PR TITLE
Send sourceUrl param in email signup

### DIFF
--- a/src/email-signup.ts
+++ b/src/email-signup.ts
@@ -30,6 +30,7 @@ export async function submitEmailSignup(
       method: 'POST',
       body: JSON.stringify({
         ...formValues,
+        sourceUrl: window.location.href,
         emailRequired,
         // Only include this if it's true
         emailToStaging: emailToStaging ? true : undefined,


### PR DESCRIPTION
## Links

- https://app.asana.com/0/1208668890181682/1209007990864550

## Description

For better visibility into where email signups are coming from. This
depends on zuplo config PR 69, although they can be merged
independently (both are backward compatible).

## Test Plan

Add `show-email`; run against Zuplo working copy. Use web inspector
and Zuplo logs to confirm the param makes it to Zuplo with the correct
value.
