### PR TITLE
Actually send gas utility to API

### DIFF
--- a/cypress/e2e/state-calculator.cy.ts
+++ b/cypress/e2e/state-calculator.cy.ts
@@ -57,24 +57,17 @@ describe('rewiring-america-state-calculator', () => {
         'To view your eligible savings programs, select a project above.',
       );
 
-    cy.selectProjects(['hvac']);
+    cy.selectProjects(['ev']);
 
-    // RI Energy incentive
-    // Note: if there are no RI-specific HVAC incentives left,
-    // please switch this test case to another state!
+    // RI state incentive
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('$750/ton off an air source heat pump');
+      .contains('Up to $1,500 off a new electric vehicle');
 
-    // 25D
+    // 30D
     cy.get('rewiring-america-state-calculator')
       .shadow()
-      .contains('30% of cost of geothermal heating installation');
-
-    // 25C
-    cy.get('rewiring-america-state-calculator')
-      .shadow()
-      .contains('$2,000 off an air source heat pump');
+      .contains('$7,500 off a new electric vehicle');
 
     cy.get('rewiring-america-state-calculator')
       .shadow()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -98,5 +98,14 @@ Cypress.Commands.add(
         .find(`li[data-value="${project}"]`)
         .click(),
     );
+
+    // Wait for the dropdown to disappear, or else it will cause spurious a11y
+    // failures (apparently because it will see the semitransparent colors of
+    // the dropdown items as they animate out, and those don't have enough
+    // contrast with the background?)
+    //
+    // It's a 100-ms animation (defined in Select.tsx), so give it 200 to be
+    // safe. This is short enough not to be annoying when running tests.
+    cy.wait(200);
   },
 );

--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -300,11 +300,11 @@ export const CalculatorForm: FC<{
           utility: utility !== OTHER_UTILITY_ID ? utility : '',
           gasUtility:
             gasUtility === OTHER_UTILITY_ID
-              ? ''
+              ? '' // Don't send the param at all
               : gasUtility === DELIVERED_FUEL_UTILITY_ID ||
                 gasUtility === NO_GAS_UTILITY_ID
-              ? 'none'
-              : '',
+              ? 'none' // Special value in the API
+              : gasUtility,
           email,
         });
       }}


### PR DESCRIPTION
## Description

If you chose an actual gas utility, as opposed to one of the "no
service" or "other" items, we just weren't sending it. Oooops

## Test Plan

Enter a MA zip (01945), choose "National Grid" in the gas utility
dropdown, and submit; make sure the param is set in the network
inspector. Even if you choose a non-Mass Save electric utility, Mass
Save incentives should come back.
