### PR TITLE
Exclude subset of HEAR rebates; remove "2024"

### DIFF
--- a/src/i18n/strings/es.ts
+++ b/src/i18n/strings/es.ts
@@ -172,7 +172,6 @@ export const templates = {
   sc0a81e0d1ea51046: `Seleccione proyecto…`,
   sc2e0d466583b17f8: `aislamiento del entrepiso`,
   sc5b20cb72269bc4f: `Los propietarios y inquilinos califican para diferentes incentivos.`,
-  sc9266b1b6ae1aad4: `Esperado en 2024-2025`,
   sc967ff75e8a58273: `Selecciona la empresa a la que paga su factura de gas.`,
   sc991c5ecbb3023ef: `aislamiento térmico`,
   sc997cfdf24ba9b58: `Aún no tenemos datos sobre las empresas de servicios eléctricos en su área.`,

--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -82,7 +82,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
     hearRebates.forEach(rebate => {
       if (
         stateExclusions !== true &&
-        (!stateExclusions || !stateExclusions.includes(rebate.project))
+        !stateExclusions.includes(rebate.project)
       ) {
         result.push({
           paymentMethod: 'pos_rebate' as IncentiveType,

--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -100,7 +100,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
           url: msg(
             'https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates',
           ),
-          timeline: msg('Expected in 2024-2025'),
+          timeline: msg('Expected in 2025'),
         });
       }
     });

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -541,10 +541,6 @@
   <source>https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates</source>
   <target>https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates</target>
 </trans-unit>
-<trans-unit id="sc9266b1b6ae1aad4">
-  <source>Expected in 2025</source>
-  <target>Esperado en 2025</target>
-</trans-unit>
 <trans-unit id="s3fba93629af19a87">
   <source>The federal guidelines allow for a discount of up to $<x id="0" equiv-text="${rebate.maxAmount.toLocaleString()}"/>.</source>
   <target>Los lineamientos federales permiten un descuento de hasta $<x id="0" equiv-text="${rebate.maxAmount.toLocaleString()}"/>.</target>

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -542,8 +542,8 @@
   <target>https://homes.rewiringamerica.org/es/federal-incentives/home-electrification-appliance-rebates</target>
 </trans-unit>
 <trans-unit id="sc9266b1b6ae1aad4">
-  <source>Expected in 2024-2025</source>
-  <target>Esperado en 2024-2025</target>
+  <source>Expected in 2025</source>
+  <target>Esperado en 2025</target>
 </trans-unit>
 <trans-unit id="s3fba93629af19a87">
   <source>The federal guidelines allow for a discount of up to $<x id="0" equiv-text="${rebate.maxAmount.toLocaleString()}"/>.</source>


### PR DESCRIPTION
## Description

- [Asana ticket for HEAR exclusions](https://app.asana.com/0/1208668890181682/1209230349019698)
- [Asana ticket for 2024 removal](https://app.asana.com/0/1208668890181682/1209248714133449)

This PR excludes dryer and stove HEAR rebates from NM, but not other HEAR rebates that haven't been rolled out yet. In order to do so, it changes the exclusion rules for HEAR rebates for specific states to more flexibly handle in-between states. It doesn't change HER rebate exclusion logic.

It also updates "Expected in" language to remove references to 2024, since that year is (regrettably?) in the past now.

## Test Plan

### Production
"Coming soon" cards are visible:

<img width="739" alt="Screenshot 2025-02-04 at 1 59 33 PM" src="https://github.com/user-attachments/assets/d3ff6f95-788d-4901-8f75-48078783b418" />

### Local
No "coming soon" rebate cards available for "Cooking stove/range" or "Clothes dryer" for >150% AMI households:

<img width="739" alt="Screenshot 2025-02-04 at 1 59 23 PM" src="https://github.com/user-attachments/assets/357da936-3762-4dd8-be30-feb03e9df172" />
