### PR TITLE
hotfix: check for existence of `stateExclusions`

### DIFF
--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -82,7 +82,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
     hearRebates.forEach(rebate => {
       if (
         stateExclusions !== true &&
-        !stateExclusions.includes(rebate.project)
+        (!stateExclusions || !stateExclusions.includes(rebate.project))
       ) {
         result.push({
           paymentMethod: 'pos_rebate' as IncentiveType,


### PR DESCRIPTION
## Description

Fixes this issue:

<img width="682" alt="Screenshot 2025-02-05 at 3 19 26 PM" src="https://github.com/user-attachments/assets/b78e5c76-b3aa-44f9-b680-823e72d04483" />

## Test Plan

Prior to making this change, made sure that I saw the error that @RandomEtc saw in production with these inputs to the calculator: `94117, PG&E, 80k, 4 people, homeowner, filing jointly`

After making this change, checked again and saw the expected cards without error
