### PR TITLE
[Calculator] - Changed Privacy Policy Link

### DIFF
--- a/cypress/e2e/calculator.cy.ts
+++ b/cypress/e2e/calculator.cy.ts
@@ -13,7 +13,7 @@ describe('rewiring-america-calculator', () => {
       .shadow()
       .contains('Available Tax Credits')
       .siblings()
-      .contains('$9,850');
+      .contains('$9,200');
     cy.get('rewiring-america-calculator')
       .shadow()
       .contains('Estimated Bill Savings Per Year')

--- a/src/calculator-footer.tsx
+++ b/src/calculator-footer.tsx
@@ -23,7 +23,7 @@ export const CalculatorFooter = () => {
           <a
             className="underline text-color-action-primary"
             target="_blank"
-            href="https://content.rewiringamerica.org/view/privacy-policy.pdf"
+            href="https://www.rewiringamerica.org/privacy-policy"
           >
             {toNbsp(msg('Privacy Policy'))}
           </a>

--- a/src/state-calculator-form.tsx
+++ b/src/state-calculator-form.tsx
@@ -177,7 +177,7 @@ const renderEmailField = (
         })}{' '}
         <a
           className="text-color-action-primary font-medium"
-          href="https://content.rewiringamerica.org/view/privacy-policy.pdf"
+          href="https://www.rewiringamerica.org/privacy-policy"
           target="_blank"
         >
           {msg('privacy policy')}


### PR DESCRIPTION
## Links:
Asana: https://app.asana.com/0/1208279958273223/1209487897449674
https://app.asana.com/0/1208668890181682/1209501301115254 

## Description

Simple one liner to change the link that the Privacy Policy notice holds. 

## Test Plan

1. Change the demo site to use the `show-email` prop [here](https://github.com/rewiringamerica/embed.rewiringamerica.org/blob/24958d5ed5b5fca100079582e50f0f4ab3784d50/src/index.html#L90-L97).
1. Run the calculator locally with [these instructions](https://github.com/rewiringamerica/embed.rewiringamerica.org?tab=readme-ov-file#run-a-development-server). 
1. Click the privacy policy link in the embedded calculator.
1. _Verify_ that it takes you to https://www.rewiringamerica.org/privacy-policy

![CleanShot 2025-02-25 at 13 31 40](https://github.com/user-attachments/assets/096a95a7-fe4e-4df6-938b-2049b28cf44f)
