### PR TITLE
Add query params to old v0 calculator for hide- attributes

### DIFF
--- a/src/calculator.tsx
+++ b/src/calculator.tsx
@@ -144,6 +144,15 @@ export class RewiringAmericaCalculator extends LitElement {
         tax_filing,
         household_size,
       });
+      if (this.hideForm) {
+        query.set('hide_form', '1');
+      }
+      if (this.hideSummary) {
+        query.set('hide_summary', '1');
+      }
+      if (this.hideResult) {
+        query.set('hide_result', '1');
+      }
       return await fetchApi<ICalculatedIncentiveResults>(
         this.apiKey,
         this.apiHost,


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/1/1200412452784804/project/1208668890181682/task/1209598337276876)

## Description

The old calculator has attributes that can be used to hide the form,
the summary section, or the detailed results. In preparation for
replacing the old calculator with the new one, we need to know if
anyone is using these attributes, because there's no equivalent of
them in the new calculator.

## Test Plan

Added these attributes to ira-calculator.html. Look in Cloud Run logs
to make sure the params are there in `jsonPayload`.
