### PR TITLE
Exclude Mass Save from location eligibility message

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -75,7 +75,7 @@ export type ItemType = (typeof ITEMS)[number];
 export interface Incentive {
   payment_methods: IncentiveType[];
   authority_type: AuthorityType;
-  authority_name: string | null;
+  authority: string | null;
   program: string;
   program_url: string;
   more_info_url?: string;

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -103,6 +103,25 @@ const getStartYearIfInFuture = (incentive: Incentive) =>
     ? getYear(incentive.start_date)
     : null;
 
+/**
+ * The API cannot precisely tell, from zip code alone, whether the user is in a
+ * specific city or county; it takes a permissive approach and returns
+ * incentives for localities the user *might* be in. So this indicates that the
+ * user should check for themselves.
+ *
+ * This is a blunt-instrument approach; in many cases there's actually no
+ * ambiguity as to which city or county a zip code is in, but the API currently
+ * doesn't take that into account.
+ *
+ * We exclude a specific set of authorities from this treatment as well, since
+ * we know they're not city- or county-dependent. This is a short-term fix; we
+ * anticipate adding a concept of "conditional eligibility" to the API, which
+ * will let us show the hedging message only when it's actually needed.
+ */
+const shouldShowLocationHedging = (incentive: Incentive) =>
+  ['city', 'county', 'other'].includes(incentive.authority_type) &&
+  !['ma-massSave'].includes(incentive.authority || '');
+
 const ComingSoonCard = ({ state }: { state: string }) => {
   const { msg } = useTranslated();
 
@@ -197,18 +216,7 @@ const renderCardCollection = (
           }
 
           const futureStartYear = getStartYearIfInFuture(incentive);
-
-          // The API cannot precisely tell, from zip code alone, whether the
-          // user is in a specific city or county; it takes a permissive
-          // approach and returns incentives for localities the user *might* be
-          // in. So this indicates that the user should check for themselves.
-          //
-          // This is a blunt-instrument approach; in many cases there's actually
-          // no ambiguity as to which city or county a zip code is in, but the
-          // API currently doesn't take that into account.
-          const locationEligibilityText = ['city', 'county', 'other'].includes(
-            incentive.authority_type,
-          )
+          const locationEligibilityText = shouldShowLocationHedging(incentive)
             ? msg('Eligibility depends on residence location.')
             : '';
 


### PR DESCRIPTION
## Links

- [Asana](https://app.asana.com/0/1208668890181682/1209741993815681)

## Description

This is a short-term fix, in anticipation of later having the API
return more detail regarding eligibility requirements that it can't be
sure you meet. This codebase is, obviously, very much the wrong place
to be conditioning logic on specific authority IDs, but we don't
expect this code to last long. (Famous last words.)

We can add any other utility-only authorities to this set as needed in
the meantime.

## Test Plan

Enter zip 01201 and choose a Mass Save utility. Look under the HVAC
project and make sure the message doesn't appear on the Mass Save
rebates.

Enter zip 80212 and look under the battery project; there are city of
Denver incentives there that should still have the hedge.
