### PR TITLE
Add coming/ending soon chips

### DIFF
--- a/src/api/calculator-types-v1.ts
+++ b/src/api/calculator-types-v1.ts
@@ -84,7 +84,6 @@ export interface Incentive {
   start_date?: string;
   end_date?: string;
   short_description?: string;
-
   eligible?: boolean;
 }
 

--- a/src/api/dates.ts
+++ b/src/api/dates.ts
@@ -1,11 +1,9 @@
 /**
- * Returns whether the given API date is unambiguously in the future, relative
- * to "now". (start_date and end_date in the API can represent a range of dates
+ * Returns the earliest possible timestamp for the given API date string.
+ * (`start_date` and `end_date` in the API can represent a range of dates
  * rather than just a single one.)
- *
- * The [now] param will be interpreted in local time.
  */
-export function isInFuture(apiDate: string, now: Date): boolean {
+export function parseApiDate(apiDate: string): number {
   // Construct the timestamp at UTC midnight on the earliest possible day that
   // the API date refers to.
   let earliestPossibleInstant: number;
@@ -30,11 +28,41 @@ export function isInFuture(apiDate: string, now: Date): boolean {
     earliestPossibleInstant = Date.UTC(parsedYear, parsedMonth, parsedDay);
   }
 
+  return earliestPossibleInstant;
+}
+
+/**
+ * Returns whether the given API date is unambiguously in the future, relative
+ * to "now". (start_date and end_date in the API can represent a range of dates
+ * rather than just a single one.)
+ *
+ * The [now] param will be interpreted in local time.
+ */
+export function isInFuture(apiDate: string, now: Date): boolean {
+  const earliestPossibleInstant = parseApiDate(apiDate);
   // Construct the timestamp at UTC midnight, with the Y/M/D of now, as
   // interpreted in local time. This avoids timezone issues by only comparing
   // timestamps with the same time and timezone component.
   const utcNow = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
   return utcNow < earliestPossibleInstant;
+}
+
+/**
+ * Returns whether the given API date is within 60 days in the future, relative
+ * to "now". (start_date and end_date in the API can represent a range of dates
+ * rather than just a single one.)
+ *
+ * The [now] param will be interpreted in local time.
+ */
+export function isChangingSoon(apiDate: string, now: Date): boolean {
+  const earliestPossibleInstant = parseApiDate(apiDate);
+  // Construct the timestamp at UTC midnight, with the Y/M/D of now, as
+  // interpreted in local time. This avoids timezone issues by only comparing
+  // timestamps with the same time and timezone component.
+  const utcNow = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+
+  const sixtyDays = 60 * 24 * 60 * 60 * 1000;
+  return utcNow + sixtyDays > earliestPossibleInstant;
 }
 
 export function getYear(apiDate: string): number {

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -5,7 +5,7 @@ import {
   Incentive,
   IncentiveType,
 } from './api/calculator-types-v1';
-import { getYear, isInFuture } from './api/dates';
+import { getYear, isChangingSoon, isInFuture } from './api/dates';
 import { Card } from './card';
 import { Option, Select } from './components/select';
 import { str } from './i18n/str';
@@ -103,6 +103,32 @@ const getStartYearIfInFuture = (incentive: Incentive) =>
     ? getYear(incentive.start_date)
     : null;
 
+// Determines if there should be a warning chip for the incentive based on
+// whether it is ending within 60 days, starting within 60 days, or starting
+// further in the future, in that order of priority.
+const isChangingSoonWarning = (
+  incentive: Incentive,
+  futureStartYear: number | null,
+  msg: MsgFn,
+) => {
+  if (incentive.end_date && isChangingSoon(incentive.end_date, new Date())) {
+    return msg('Ending soon');
+  }
+
+  if (
+    incentive.start_date &&
+    isChangingSoon(incentive.start_date, new Date())
+  ) {
+    return msg('Coming soon');
+  }
+
+  if (futureStartYear) {
+    msg(str`Expected in ${futureStartYear}`);
+  }
+
+  return null;
+};
+
 const ComingSoonCard = ({ state }: { state: string }) => {
   const { msg } = useTranslated();
 
@@ -197,6 +223,11 @@ const renderCardCollection = (
           }
 
           const futureStartYear = getStartYearIfInFuture(incentive);
+          const timeSensitiveWarning = isChangingSoonWarning(
+            incentive,
+            futureStartYear,
+            msg,
+          );
 
           // The API cannot precisely tell, from zip code alone, whether the
           // user is in a specific city or county; it takes a permissive
@@ -225,11 +256,7 @@ const renderCardCollection = (
               headline={headline}
               subHeadline={incentive.program}
               body={`${incentive.short_description} ${locationEligibilityText}`}
-              warningChip={
-                futureStartYear
-                  ? msg(str`Expected in ${futureStartYear}`)
-                  : null
-              }
+              warningChip={timeSensitiveWarning}
               buttonUrl={buttonUrl}
               buttonText={buttonText}
             />


### PR DESCRIPTION
## Description

- 2/3 of [this ticket](https://app.asana.com/0/1208668890181682/1209457335806138/f). The `paused` chip will be added once that property has been exported from HERO to the API (an oversight from my previous work adding it to HERO)
- "Ending soon" shows if the `end_date` is within 60 days from now
- if that is falsy, then "Coming soon" shows if `start_date` is within 60 days
- and if that is also falsy, but the incentive is starting in a "future year" (which includes later in 2025), it falls back to the existing logic that shows "Expected in 202{x}"
- otherwise, it doesn't show a time-related warning chip

## Test Plan

- I mocked an incentive with relevant start/end dates and manually tested

<img width="331" alt="Screenshot 2025-03-21 at 6 58 07 AM" src="https://github.com/user-attachments/assets/232dce6f-cd6c-4f99-9e1d-afec6cd3ca94" />
<img width="329" alt="Screenshot 2025-03-21 at 6 58 25 AM" src="https://github.com/user-attachments/assets/9a7eea56-305b-4a52-9c2d-3cdb745870c6" />
