### PR TITLE
hotfix: only show chip if incentive is changing in the future

### DIFF
--- a/src/api/dates.ts
+++ b/src/api/dates.ts
@@ -62,7 +62,12 @@ export function isChangingSoon(apiDate: string, now: Date): boolean {
   const utcNow = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
 
   const sixtyDays = 60 * 24 * 60 * 60 * 1000;
-  return utcNow + sixtyDays > earliestPossibleInstant;
+  const sixtyDaysFromNow = utcNow + sixtyDays;
+
+  return (
+    earliestPossibleInstant > utcNow &&
+    sixtyDaysFromNow > earliestPossibleInstant
+  );
 }
 
 export function getYear(apiDate: string): number {


### PR DESCRIPTION
## Description

the previous logic was showing "Coming soon" chips for federal incentives that started in 2023. This addition makes sure that `isChangingSoon` is only `true` if the `apiDate` is in the future **and** within sixty dates from now.

## Test Plan

no longer seeing "Coming soon" for this card:

<img width="667" alt="Screenshot 2025-03-27 at 2 15 44 PM" src="https://github.com/user-attachments/assets/a27ea18f-d2ca-409d-9650-562c7203606d" />
