### PR TITLE
fix misalignment for multi-line select items

### DIFF
--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -205,15 +205,13 @@ export const Select = <T extends string>({
                   o.disabled && 'opacity-50',
                 )}
               >
-                {currentValue === o.value ? (
-                  <Check w={20} h={20} />
-                ) : (
-                  <div className="w-5" />
-                )}
+                <div className="w-5 shrink-0">
+                  {currentValue === o.value && <Check w={20} h={20} />}
+                </div>
                 {o.getIcon && (
                   <span className="text-lg text-grey-700">{o.getIcon()}</span>
                 )}
-                <span className="grow text-color-text-primary">{o.label}</span>
+                <span className="text-color-text-primary">{o.label}</span>
                 {o.badge !== undefined && <Badge num={o.badge} />}
               </Listbox.Option>
             ))}


### PR DESCRIPTION
## Description

`div`s were shrinking due to flexbox magic when option labels spilled over into multiple lines. This happened in both languages in all dropdowns. This change prevents the selected checkbox  or its container from shrinking.

## Test Plan

### Before
<img width="348" alt="Screenshot 2025-04-02 at 3 52 43 PM" src="https://github.com/user-attachments/assets/fc579669-8085-41b3-8a60-411048344cc9" />
<img width="349" alt="Screenshot 2025-04-02 at 3 53 23 PM" src="https://github.com/user-attachments/assets/f84478df-ca26-459d-937e-7360298bba49" />

### After
<img width="347" alt="Screenshot 2025-04-02 at 3 53 02 PM" src="https://github.com/user-attachments/assets/f6a9667c-ec50-49ac-af07-324fd75a5cd8" />
<img width="349" alt="Screenshot 2025-04-02 at 3 51 06 PM" src="https://github.com/user-attachments/assets/5ced1768-e112-4f08-9321-5c73137248bc" />