### PR TITLE
Do not show timeline chips for IRA programs for MA

### DIFF
--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -78,6 +78,9 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
   );
   const maxHerRebate = response.is_under_80_ami ? 8000 : 4000;
   const stateExclusions = HEAR_EXCLUSION_RULES[response.location.state];
+  // Mass Save includes HEAR/HER rebates, so we should not show the timeline chip for that location
+  const timeline =
+    response.location.state === 'MA' ? null : msg('Expected in 2025');
   const result: IRARebate[] = [];
 
   if (response.is_under_150_ami) {
@@ -102,7 +105,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
           url: msg(
             'https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates',
           ),
-          timeline: msg('Expected in 2025'),
+          timeline: timeline,
         });
       }
     });
@@ -123,7 +126,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
       url: msg(
         'https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates',
       ),
-      timeline: msg('Expected in 2025'),
+      timeline: timeline,
     });
   }
 


### PR DESCRIPTION
## Description
Since MA is now live, remove the "expected in 2025" chips for IRA programs since they chose to roll the money into Mass Save.

https://app.asana.com/0/1208668890181682/1209811787832381/f

## Test Plan
Used MA zip  `02116` to validate chips do not show. Then used a CO zip to validate the chips still showed.