### PR TITLE
Filter out un-headlineable incentives

### DIFF
--- a/src/item-name.ts
+++ b/src/item-name.ts
@@ -225,39 +225,6 @@ const multipleItemsName = (items: ItemType[], msg: MsgFn) => {
   return null;
 };
 
-// Returns false if the incentive includes more than one item, and the items are
-// under the same project but do not belong to a singular headline group.
-//
-// This is used to filter out un-headlineable incentives from the incentive count
-// in the project selector
-export function isIncentiveHeadlineable(
-  incentiveItems: ItemType[],
-  project: Project,
-) {
-  if (incentiveItems.length === 1) {
-    return true;
-  }
-  for (const { members } of ITEM_GROUPS) {
-    if (itemsBelongToGroup(incentiveItems, members)) {
-      return true;
-    }
-  }
-
-  const itemsToRender = incentiveItems.filter(item =>
-    PROJECTS[project].items.includes(item),
-  );
-
-  if (itemsToRender.length > 1) {
-    for (const { members } of ITEM_GROUPS) {
-      if (itemsBelongToGroup(itemsToRender, members)) {
-        return true;
-      }
-    }
-  }
-
-  return itemsToRender.length === 1;
-}
-
 /**
  * TODO this is an internationalization sin. Figure out something better!
  */

--- a/src/item-name.ts
+++ b/src/item-name.ts
@@ -225,6 +225,39 @@ const multipleItemsName = (items: ItemType[], msg: MsgFn) => {
   return null;
 };
 
+// Returns false if the incentive includes more than one item, and the items are
+// under the same project but do not belong to a singular headline group.
+//
+// This is used to filter out un-headlineable incentives from the incentive count
+// in the project selector
+export function isIncentiveHeadlineable(
+  incentiveItems: ItemType[],
+  project: Project,
+) {
+  if (incentiveItems.length === 1) {
+    return true;
+  }
+  for (const { members } of ITEM_GROUPS) {
+    if (itemsBelongToGroup(incentiveItems, members)) {
+      return true;
+    }
+  }
+
+  const itemsToRender = incentiveItems.filter(item =>
+    PROJECTS[project].items.includes(item),
+  );
+
+  if (itemsToRender.length > 1) {
+    for (const { members } of ITEM_GROUPS) {
+      if (itemsBelongToGroup(itemsToRender, members)) {
+        return true;
+      }
+    }
+  }
+
+  return itemsToRender.length === 1;
+}
+
 /**
  * TODO this is an internationalization sin. Figure out something better!
  */

--- a/src/results.ts
+++ b/src/results.ts
@@ -1,6 +1,7 @@
 import { APIResponse, Incentive } from './api/calculator-types-v1';
 import { MsgFn } from './i18n/use-translated';
 import { IRARebate, getRebatesFor } from './ira-rebates';
+import { isIncentiveHeadlineable } from './item-name';
 import { PROJECTS, Project } from './projects';
 
 export type Results = {
@@ -29,8 +30,10 @@ export function getResultsForDisplay(
   const incentivesByProject = Object.fromEntries(
     Object.entries(projects).map(([project, projectInfo]) => [
       project,
-      response.incentives.filter(incentive =>
-        incentive.items.some(item => projectInfo.items.includes(item)),
+      response.incentives.filter(
+        incentive =>
+          incentive.items.some(item => projectInfo.items.includes(item)) &&
+          isIncentiveHeadlineable(incentive.items, project as Project),
       ),
     ]),
   ) as Record<Project, Incentive[]>;

--- a/src/results.ts
+++ b/src/results.ts
@@ -1,7 +1,7 @@
 import { APIResponse, Incentive } from './api/calculator-types-v1';
-import { MsgFn } from './i18n/use-translated';
+import { MsgFn, passthroughMsg } from './i18n/use-translated';
 import { IRARebate, getRebatesFor } from './ira-rebates';
-import { isIncentiveHeadlineable } from './item-name';
+import { itemName } from './item-name';
 import { PROJECTS, Project } from './projects';
 
 export type Results = {
@@ -33,7 +33,9 @@ export function getResultsForDisplay(
       response.incentives.filter(
         incentive =>
           incentive.items.some(item => projectInfo.items.includes(item)) &&
-          isIncentiveHeadlineable(incentive.items, project as Project),
+          // Filter out incentives where items array does not have a matching headline
+          itemName(incentive.items, passthroughMsg, project as Project) !==
+            null,
       ),
     ]),
   ) as Record<Project, Incentive[]>;


### PR DESCRIPTION
## Description
[Asana](https://app.asana.com/1/1200412452784804/project/1208032460888564/task/1209830569676165?focus=true)

## Test Plan
- Manually set a incentive on local API instance to `items: [other_heatpump, smart_thermostat]`, which is un-headlinable

|  |  |
|--------------------------|--------------------|
| Before (wrong project count) | ![Screenshot 2025-04-10 at 2 20 00 PM](https://github.com/user-attachments/assets/f3b1264c-e27c-4f89-858f-12fdead68c98) |
| After                    | ![Screenshot 2025-04-10 at 2 21 12 PM](https://github.com/user-attachments/assets/874f7fc9-344e-48a3-a30a-08d636954967) |

