### PR TITLE
Fix anchor position after form submit

### DIFF
--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -242,12 +242,12 @@ const StateCalculator: FC<{
   };
 
   // When the fetch completes, scroll to the appropriate element
-  const resultsRef = useRef<HTMLDivElement>(null);
+  const calcContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const target =
-      fetchState.state === 'complete' && resultsRef.current
-        ? resultsRef.current
+      fetchState.state === 'complete' && calcContainerRef.current
+        ? calcContainerRef.current
         : null;
 
     if (target) {
@@ -298,7 +298,7 @@ const StateCalculator: FC<{
       <div
         id="calc-root"
         className="grid gap-8 scroll-m-[90px]"
-        ref={resultsRef}
+        ref={calcContainerRef}
       >
         <Card padding="small">
           <FormSnapshot

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -253,8 +253,8 @@ const StateCalculator: FC<{
     if (target) {
       scrollIntoView(target, {
         behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
+        block: 'start',
+        inline: 'start',
         scrollMode: 'if-needed',
       });
     }

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -285,7 +285,6 @@ const StateCalculator: FC<{
     } else {
       incentiveResults = (
         <IncentiveGrid
-          ref={resultsRef}
           incentivesByProject={incentivesByProject}
           iraRebatesByProject={iraRebatesByProject}
           coverageState={response.coverage.state}
@@ -296,7 +295,11 @@ const StateCalculator: FC<{
     }
 
     return (
-      <div id="calc-root" className="grid gap-8">
+      <div
+        id="calc-root"
+        className="grid gap-8 scroll-m-[24px]"
+        ref={resultsRef}
+      >
         <Card padding="small">
           <FormSnapshot
             formLabels={submittedLabels!}

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -295,11 +295,7 @@ const StateCalculator: FC<{
     }
 
     return (
-      <div
-        id="calc-root"
-        className="grid gap-8 scroll-m-[24px]"
-        ref={resultsRef}
-      >
+      <div id="calc-root" className="grid gap-8 scroll-m-6" ref={resultsRef}>
         <Card padding="small">
           <FormSnapshot
             formLabels={submittedLabels!}

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -295,7 +295,11 @@ const StateCalculator: FC<{
     }
 
     return (
-      <div id="calc-root" className="grid gap-8 scroll-m-6" ref={resultsRef}>
+      <div
+        id="calc-root"
+        className="grid gap-8 scroll-m-[90px]"
+        ref={resultsRef}
+      >
         <Card padding="small">
           <FormSnapshot
             formLabels={submittedLabels!}

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -1,5 +1,5 @@
 import ProjectIcon from 'jsx:../static/icons/project.svg';
-import React, { forwardRef, useState } from 'react';
+import React, { useState } from 'react';
 import {
   AmountUnit,
   Incentive,
@@ -308,82 +308,77 @@ type IncentiveGridProps = {
   tabs: { project: Project; count: number }[];
 };
 
-export const IncentiveGrid = forwardRef<HTMLDivElement, IncentiveGridProps>(
-  (
-    {
-      incentivesByProject,
-      iraRebatesByProject,
-      coverageState,
-      locationState,
-      tabs,
-    },
-    ref,
-  ) => {
-    const { msg } = useTranslated();
+export const IncentiveGrid = ({
+  incentivesByProject,
+  iraRebatesByProject,
+  coverageState,
+  locationState,
+  tabs,
+}: IncentiveGridProps) => {
+  const { msg } = useTranslated();
 
-    // If a project selection is saved in local storage AND that project has
-    // nonzero incentives, select that project.
-    //
-    // Otherwise, select the first project in the menu (which, by virtue of the
-    // sorting above, will have incentives unless there are zero results total).
-    const [projectTab, setProjectTab] = useState(() => {
-      const storedProject = safeLocalStorage.getItem(
-        SELECTED_PROJECT_LOCAL_STORAGE_KEY,
-      );
-
-      if (
-        storedProject !== null &&
-        incentivesByProject[storedProject]?.length > 0
-      ) {
-        return storedProject;
-      } else {
-        safeLocalStorage.removeItem(SELECTED_PROJECT_LOCAL_STORAGE_KEY);
-        return null;
-      }
-    });
-
-    const options: Option<Project>[] = tabs.map(({ project, count }) => ({
-      value: project,
-      label: PROJECTS[project].label(msg),
-      getIcon: PROJECT_ICONS[project],
-      badge: count,
-      disabled: count === 0,
-    }));
-
-    return (
-      <>
-        <div className="min-w-50" ref={ref}>
-          <Select
-            id="project-selector"
-            labelText={msg('Project', { desc: 'label for a selector input' })}
-            hiddenLabel={true}
-            placeholder={msg('Select project…')}
-            currentValue={projectTab}
-            options={options}
-            onChange={project => {
-              safeLocalStorage.setItem(
-                SELECTED_PROJECT_LOCAL_STORAGE_KEY,
-                project,
-              );
-              setProjectTab(project);
-            }}
-          />
-        </div>
-        {projectTab !== null ? (
-          <CardCollection
-            incentives={incentivesByProject[projectTab]}
-            iraRebates={iraRebatesByProject[projectTab]}
-            coverageState={coverageState}
-            locationState={locationState}
-            project={projectTab}
-          />
-        ) : (
-          renderSelectProjectCard()
-        )}
-      </>
+  // If a project selection is saved in local storage AND that project has
+  // nonzero incentives, select that project.
+  //
+  // Otherwise, select the first project in the menu (which, by virtue of the
+  // sorting above, will have incentives unless there are zero results total).
+  const [projectTab, setProjectTab] = useState(() => {
+    const storedProject = safeLocalStorage.getItem(
+      SELECTED_PROJECT_LOCAL_STORAGE_KEY,
     );
-  },
-);
+
+    if (
+      storedProject !== null &&
+      incentivesByProject[storedProject]?.length > 0
+    ) {
+      return storedProject;
+    } else {
+      safeLocalStorage.removeItem(SELECTED_PROJECT_LOCAL_STORAGE_KEY);
+      return null;
+    }
+  });
+
+  const options: Option<Project>[] = tabs.map(({ project, count }) => ({
+    value: project,
+    label: PROJECTS[project].label(msg),
+    getIcon: PROJECT_ICONS[project],
+    badge: count,
+    disabled: count === 0,
+  }));
+
+  return (
+    <>
+      <div className="min-w-50">
+        <Select
+          id="project-selector"
+          labelText={msg('Project', { desc: 'label for a selector input' })}
+          hiddenLabel={true}
+          placeholder={msg('Select project…')}
+          currentValue={projectTab}
+          options={options}
+          onChange={project => {
+            safeLocalStorage.setItem(
+              SELECTED_PROJECT_LOCAL_STORAGE_KEY,
+              project,
+            );
+            setProjectTab(project);
+          }}
+        />
+      </div>
+      {projectTab !== null ? (
+        <CardCollection
+          incentives={incentivesByProject[projectTab]}
+          iraRebates={iraRebatesByProject[projectTab]}
+          coverageState={coverageState}
+          locationState={locationState}
+          project={projectTab}
+        />
+      ) : (
+        renderSelectProjectCard()
+      )}
+    </>
+  );
+};
 
 /**
  * If you make a backward-incompatible change to the format of form value


### PR DESCRIPTION
## Description

Once I moved the target element up to the state calculator container as a whole, the "nearest" option for `scroll-if-needed` didn't make sense anymore, because it could scroll to the bottom of the calculator itself! I switched to "start" so that the scroll is at the top.

## Test Plan

Scrolled to the bottom of the page (where the form submit is only just visible at the top) and made sure that it scrolled up to the top of the summary card after submit, plus additional padding to account for the floating header at homes.rewiringamerica.org/calculator

https://github.com/user-attachments/assets/02916665-21cc-4cfc-a6d0-f15c8400c6c8

