### PR TITLE
Remove HEAR/HER cards for MA

### DIFF
--- a/src/ira-rebates.ts
+++ b/src/ira-rebates.ts
@@ -63,6 +63,7 @@ const HEAR_EXCLUSION_RULES: Record<string, true | Project[]> = {
   DC: true,
   GA: true,
   ID: true,
+  MA: true,
   ME: true,
   MD: true,
   NY: true,
@@ -70,7 +71,16 @@ const HEAR_EXCLUSION_RULES: Record<string, true | Project[]> = {
   SD: true,
   NM: ['cooking', 'clothes_dryer'], // only exclude stoves and dryers in NM for now
 };
-const HER_EXCLUDE_STATES = new Set(['DC', 'GA', 'ID', 'ME', 'NY', 'SD', 'WI']);
+const HER_EXCLUDE_STATES = new Set([
+  'DC',
+  'GA',
+  'ID',
+  'MA',
+  'ME',
+  'NY',
+  'SD',
+  'WI',
+]);
 
 export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
   const disclaimerText = msg(
@@ -78,9 +88,6 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
   );
   const maxHerRebate = response.is_under_80_ami ? 8000 : 4000;
   const stateExclusions = HEAR_EXCLUSION_RULES[response.location.state];
-  // Mass Save includes HEAR/HER rebates, so we should not show the timeline chip for that location
-  const timeline =
-    response.location.state === 'MA' ? null : msg('Expected in 2025');
   const result: IRARebate[] = [];
 
   if (response.is_under_150_ami) {
@@ -105,7 +112,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
           url: msg(
             'https://homes.rewiringamerica.org/federal-incentives/home-electrification-appliance-rebates',
           ),
-          timeline,
+          timeline: msg('Expected in 2025'),
         });
       }
     });
@@ -126,7 +133,7 @@ export function getRebatesFor(response: APIResponse, msg: MsgFn): IRARebate[] {
       url: msg(
         'https://homes.rewiringamerica.org/federal-incentives/home-efficiency-rebates',
       ),
-      timeline,
+      timeline: msg('Expected in 2025'),
     });
   }
 


### PR DESCRIPTION
I think this was the actual intent of this task (https://app.asana.com/1/1200412452784804/project/1208668890181682/task/1209811787832381) but wires got crossed and it was implemented as removing the "expected in 2025" text.

## Test Plan

Run with zip 02116 and make sure no HEAR/HER cards are in any of the projects.
