### PR TITLE
Calculator style refinements

### DIFF
--- a/src/calculator-footer.tsx
+++ b/src/calculator-footer.tsx
@@ -7,7 +7,7 @@ export const CalculatorFooter = () => {
   const { msg } = useTranslated();
   return (
     <slot name="footer">
-      <div className="calculator-footer min-w-50 mt-4 text-center">
+      <div className="calculator-footer min-w-50 mt-6 text-center">
         <p className="leading-normal">
           {toNbsp(
             msg('Calculator by', { desc: 'followed by "Rewiring America"' }),

--- a/src/card.tsx
+++ b/src/card.tsx
@@ -4,25 +4,25 @@ import clsx from 'clsx';
 
 /**
  * Renders a padded card with white background and drop shadow. "isFlat" uses
- * a yellow background and no shadow instead. Children are placed in a
- * 1-column grid.
+ * no shadow instead. Children are placed in a 1-column grid.
  */
 export const Card = forwardRef<
   HTMLDivElement,
   PropsWithChildren<{
     id?: string;
-    theme?: 'white' | 'grey';
+    isFlat?: boolean;
     padding: 'small' | 'medium' | 'large';
+    theme?: 'white' | 'grey';
   }>
->(({ id, theme, children, padding }, ref) => (
+>(({ children, id, isFlat, padding, theme }, ref) => (
   <div
     ref={ref}
     id={id}
     className={clsx(
-      'rounded-xl',
-      'min-w-52',
-      theme === 'grey' && 'bg-[#efefef] border border-grey-200',
-      (!theme || theme === 'white') && 'bg-white shadow',
+      'rounded-xl min-w-52 border border-grey-200',
+      theme === 'grey' && 'bg-[#efefef]',
+      (!theme || theme === 'white') && 'bg-white',
+      isFlat ? 'shadow-none' : 'shadow',
     )}
   >
     <div

--- a/src/form-snapshot.tsx
+++ b/src/form-snapshot.tsx
@@ -39,13 +39,13 @@ export const FormSnapshot: React.FC<Props> = ({
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="leading-normal text-color-text-primary">
+    <div className="flex flex-col gap-4">
+      <h3 className="leading-normal text-color-text-primary text-lg">
         <span className="font-medium">{title}</span>{' '}
         {msg('based on your household information.', {
           desc: 'preceded by "we found N projects"',
         })}
-      </div>
+      </h3>
       <ul className="text-sm text-grey-600 leading-normal">
         <li>
           <span className="font-medium">

--- a/src/incentive-card.tsx
+++ b/src/incentive-card.tsx
@@ -106,17 +106,17 @@ export const IncentiveCard: FC<{
 }) => (
   <Card padding="small">
     <div className="flex gap-4 justify-between items-baseline">
-      <div className="text-grey-900 text-lg font-medium leading-normal">
+      <h4 className="text-grey-900 text-lg font-medium leading-normal">
         {headline}
-      </div>
+      </h4>
       {/* Only appears on medium and wide layout */}
       <BorderlessLinkButton href={buttonUrl}>
         {buttonText} <ExternalLink w={20} h={20} />
       </BorderlessLinkButton>
     </div>
-    <div className="text-grey-400 text-base font-medium leading-tight">
+    <h5 className="text-grey-400 text-base font-medium leading-tight">
       {subHeadline}
-    </div>
+    </h5>
     <div className="text-grey-600 text-base leading-normal">{body}</div>
     <div className="flex flex-wrap gap-2.5">
       <Chip>{typeChip}</Chip>

--- a/src/partner-logos.tsx
+++ b/src/partner-logos.tsx
@@ -41,7 +41,7 @@ export const PartnerLogos = ({ response }: Props) => {
       <h2 className="text-center text-grey-700 text-lg leading-tight font-medium mb-[8px]">
         {title}
       </h2>
-      <div className="flex flex-wrap justify-center items-start gap-x-12 gap-y-6">
+      <div className="flex flex-wrap justify-center items-start gap-x-12 gap-y-4">
         {logos}
       </div>
     </Card>

--- a/src/partner-logos.tsx
+++ b/src/partner-logos.tsx
@@ -1,4 +1,5 @@
 import { APIResponse } from './api/calculator-types-v1';
+import { Card } from './card';
 import { useTranslated } from './i18n/use-translated';
 
 type Props = { response: APIResponse };
@@ -25,7 +26,7 @@ export const PartnerLogos = ({ response }: Props) => {
       key={id}
       alt={partner.name}
       src={partner.logo!.src}
-      width={partner.logo!.width}
+      width={Math.min(274, partner.logo!.width)}
       height={partner.logo!.height}
     />
   ));
@@ -35,13 +36,15 @@ export const PartnerLogos = ({ response }: Props) => {
   });
 
   return (
-    <div className="w-full max-w-7xl bg-white">
-      <h2 className="mx-6 mt-8 sm:mt-12 mb-12 sm:mb-16 text-center text-grey-700 text-xl sm:text-3xl leading-tight font-medium">
+    // <div className="w-full max-w-7xl bg-white p-4 border border-grey-200 rounded-xl">
+    <Card padding="small" isFlat>
+      <h2 className="text-center text-grey-700 text-lg leading-tight font-medium mb-[8px]">
         {title}
       </h2>
-      <div className="flex flex-wrap justify-center items-start gap-16 mb-20">
+      <div className="flex flex-wrap justify-center items-start gap-4">
         {logos}
       </div>
-    </div>
+    </Card>
+    // </div>
   );
 };

--- a/src/partner-logos.tsx
+++ b/src/partner-logos.tsx
@@ -41,7 +41,7 @@ export const PartnerLogos = ({ response }: Props) => {
       <h2 className="text-center text-grey-700 text-lg leading-tight font-medium mb-[8px]">
         {title}
       </h2>
-      <div className="flex flex-wrap justify-center items-start gap-4">
+      <div className="flex flex-wrap justify-center items-start gap-x-12 gap-y-6">
         {logos}
       </div>
     </Card>

--- a/src/partner-logos.tsx
+++ b/src/partner-logos.tsx
@@ -36,7 +36,6 @@ export const PartnerLogos = ({ response }: Props) => {
   });
 
   return (
-    // <div className="w-full max-w-7xl bg-white p-4 border border-grey-200 rounded-xl">
     <Card padding="small" isFlat>
       <h2 className="text-center text-grey-700 text-lg leading-tight font-medium mb-[8px]">
         {title}
@@ -45,6 +44,5 @@ export const PartnerLogos = ({ response }: Props) => {
         {logos}
       </div>
     </Card>
-    // </div>
   );
 };

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -141,6 +141,55 @@ const fetch = (
     .catch(exc => setFetchState({ state: 'error', message: exc.message }));
 };
 
+const ComingSoonCard = ({ state }: { state: string }) => {
+  const { msg } = useTranslated();
+
+  // Show link to The Switch is On for states where they have good coverage.
+  const url = new URL('https://incentives.switchison.org/residents/incentives');
+  url.searchParams.set('state', state);
+  url.searchParams.set('utm_source', 'partner');
+  url.searchParams.set('utm_medium', 'referral');
+  url.searchParams.set('utm_campaign', 'rewiring_america');
+  const body =
+    state === 'CA' || state === 'WA' ? (
+      <>
+        {msg(
+          str`While we don't have detailed state and local utility coverage \
+for ${STATES[state].name(msg)},`,
+          { desc: 'followed by "The Switch is On is a ...' },
+        )}{' '}
+        <a
+          className="text-color-action-primary hover:underline"
+          href={url.toString()}
+          target="_blank"
+        >
+          The Switch is On
+        </a>{' '}
+        {msg(
+          `is a comprehensive resource that includes detailed information for your state.`,
+          { desc: 'preceded by "The Switch is On", name of an organization' },
+        )}
+      </>
+    ) : (
+      msg(
+        `You can take advantage of federal incentives now, but your state, \
+city, and utility may also provide incentives for this project. We’re working \
+hard to identify each one!`,
+      )
+    );
+
+  return (
+    <Card theme="grey" padding="medium">
+      <h3 className="text-color-text-primary text-center text-xl font-medium leading-tight">
+        {msg('More money coming soon!')}
+      </h3>
+      <p className="text-color-text-primary text-center text-base leading-normal">
+        {body}
+      </p>
+    </Card>
+  );
+};
+
 const StateCalculator: FC<{
   shadowRoot: ShadowRoot;
   apiHost: string;
@@ -280,6 +329,8 @@ const StateCalculator: FC<{
       totalResults,
       countOfProjects,
     } = getResultsForDisplay(response, msg, projectFilter);
+    const coverageState = response.coverage.state;
+    const locationState = response.location.state;
 
     let incentiveResults;
     if (projectFilter.length === 1) {
@@ -288,8 +339,6 @@ const StateCalculator: FC<{
         <CardCollection
           incentives={incentivesByProject[selectedProject]}
           iraRebates={iraRebatesByProject[selectedProject]}
-          coverageState={response.coverage.state}
-          locationState={response.location.state}
           project={selectedProject}
         />
       );
@@ -298,8 +347,6 @@ const StateCalculator: FC<{
         <IncentiveGrid
           incentivesByProject={incentivesByProject}
           iraRebatesByProject={iraRebatesByProject}
-          coverageState={response.coverage.state}
-          locationState={response.location.state}
           tabs={projectOptions}
         />
       );
@@ -308,10 +355,10 @@ const StateCalculator: FC<{
     return (
       <div
         id="calc-root"
-        className="grid gap-8 scroll-m-[90px]"
+        className="grid gap-6 scroll-m-[90px]"
         ref={calcContainerRef}
       >
-        <Card padding="small">
+        <Card padding="small" isFlat>
           <FormSnapshot
             formLabels={submittedLabels!}
             totalResults={totalResults}
@@ -321,6 +368,7 @@ const StateCalculator: FC<{
           />
         </Card>
         {incentiveResults}
+        {coverageState === null && <ComingSoonCard state={locationState} />}
         <PartnerLogos response={response} />
       </div>
     );

--- a/src/state-calculator.tsx
+++ b/src/state-calculator.tsx
@@ -179,7 +179,7 @@ hard to identify each one!`,
     );
 
   return (
-    <Card theme="grey" padding="medium">
+    <Card theme="grey" padding="medium" isFlat>
       <h3 className="text-color-text-primary text-center text-xl font-medium leading-tight">
         {msg('More money coming soon!')}
       </h3>

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -16,7 +16,6 @@ import { itemName } from './item-name';
 import { PROJECT_ICONS } from './project-icons';
 import { PROJECTS, Project } from './projects';
 import { safeLocalStorage } from './safe-local-storage';
-import { STATES } from './states';
 
 const formatUnit = (unit: AmountUnit, msg: MsgFn) =>
   unit === 'btuh10k'
@@ -152,55 +151,6 @@ const generateTimeSensitiveMessages = (
   return null;
 };
 
-const ComingSoonCard = ({ state }: { state: string }) => {
-  const { msg } = useTranslated();
-
-  // Show link to The Switch is On for states where they have good coverage.
-  const url = new URL('https://incentives.switchison.org/residents/incentives');
-  url.searchParams.set('state', state);
-  url.searchParams.set('utm_source', 'partner');
-  url.searchParams.set('utm_medium', 'referral');
-  url.searchParams.set('utm_campaign', 'rewiring_america');
-  const body =
-    state === 'CA' || state === 'WA' ? (
-      <>
-        {msg(
-          str`While we don't have detailed state and local utility coverage \
-for ${STATES[state].name(msg)},`,
-          { desc: 'followed by "The Switch is On is a ...' },
-        )}{' '}
-        <a
-          className="text-color-action-primary hover:underline"
-          href={url.toString()}
-          target="_blank"
-        >
-          The Switch is On
-        </a>{' '}
-        {msg(
-          `is a comprehensive resource that includes detailed information for your state.`,
-          { desc: 'preceded by "The Switch is On", name of an organization' },
-        )}
-      </>
-    ) : (
-      msg(
-        `You can take advantage of federal incentives now, but your state, \
-city, and utility may also provide incentives for this project. We’re working \
-hard to identify each one!`,
-      )
-    );
-
-  return (
-    <Card theme="grey" padding="medium">
-      <h3 className="text-color-text-primary text-center text-xl font-medium leading-tight">
-        {msg('More money coming soon!')}
-      </h3>
-      <p className="text-color-text-primary text-center text-base leading-normal">
-        {body}
-      </p>
-    </Card>
-  );
-};
-
 const renderSelectProjectCard = () => {
   const { msg } = useTranslated();
   return (
@@ -224,15 +174,11 @@ const renderSelectProjectCard = () => {
 type CardCollectionProps = {
   incentives: Incentive[];
   iraRebates: IRARebate[];
-  coverageState: string | null;
-  locationState: string;
   project: Project;
 };
 export const CardCollection: React.FC<CardCollectionProps> = ({
   incentives,
   iraRebates,
-  coverageState,
-  locationState,
   project,
 }) => {
   const { msg } = useTranslated();
@@ -295,7 +241,6 @@ export const CardCollection: React.FC<CardCollectionProps> = ({
             />
           )),
         )}
-      {coverageState === null && <ComingSoonCard state={locationState} />}
     </div>
   );
 };
@@ -303,16 +248,12 @@ export const CardCollection: React.FC<CardCollectionProps> = ({
 type IncentiveGridProps = {
   incentivesByProject: Record<Project, Incentive[]>;
   iraRebatesByProject: Record<Project, IRARebate[]>;
-  coverageState: string | null;
-  locationState: string;
   tabs: { project: Project; count: number }[];
 };
 
 export const IncentiveGrid = ({
   incentivesByProject,
   iraRebatesByProject,
-  coverageState,
-  locationState,
   tabs,
 }: IncentiveGridProps) => {
   const { msg } = useTranslated();
@@ -369,8 +310,6 @@ export const IncentiveGrid = ({
         <CardCollection
           incentives={incentivesByProject[projectTab]}
           iraRebates={iraRebatesByProject[projectTab]}
-          coverageState={coverageState}
-          locationState={locationState}
           project={projectTab}
         />
       ) : (

--- a/src/state-incentive-details.tsx
+++ b/src/state-incentive-details.tsx
@@ -154,7 +154,7 @@ const generateTimeSensitiveMessages = (
 const renderSelectProjectCard = () => {
   const { msg } = useTranslated();
   return (
-    <Card theme="grey" padding="large">
+    <Card theme="grey" padding="large" isFlat>
       <ProjectIcon
         className="mx-auto text-grey-500"
         width={120}


### PR DESCRIPTION
## Description

- [Asana](https://app.asana.com/1/1200412452784804/project/1208668890181682/task/1209874056315444?focus=true)
- [Figma](https://www.figma.com/design/BRxaHYt1ytgBgq9xpmQqQj/Savings-Calculator--25?node-id=348-1269&m=dev)

Changes include:

Household snapshot section
- No box shadow
- Stroke set to grey-200 (E2E2E2)
- Heading set to subhead4 (20/125)
- Spacing set to 16px (between heading, fields, and edit button)

- Incentive cards stroke set to grey-200(E2E2E2)

Data partnership acknowledgement section 
- Heading set to subhead 4
- Logo max-width set to 274px
- Logo spacing set to 24px
- Section spacing set to 24px (between heading and logos)

- Embed gap set to 24px - between snapshot section, project selector, results list (and ‘more money..’  banner), and data partnership acknowledgement

- Results list gap set to 16px - includes ‘More money coming..’ banner.

## Test Plan

Looked at it :)

- both mobile and desktop (easy because this branch removes some of the viewport-dependent logic)

- 20002 zip code for the partnerships section
- 98039 zip code for the "more money coming soon" section

The following screenshot shows both cards to make sure that the spacing was working as expected, but in production they wouldn't both show in any real-life scenarios (I believe)

<img width="494" alt="Screenshot 2025-05-01 at 2 23 50 PM" src="https://github.com/user-attachments/assets/efc49c2b-964f-49b0-a6e5-e929d036a1d4" />
