### PR TITLE
Give bill impact calculator its own JS entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "targets": {
     "default": {
       "source": [
+        "src/bill-impact-calculator.ts",
         "src/calculator.ts",
         "src/state-calculator.ts",
         "src/rewiring-fonts.css",

--- a/src/bill-impact-calculator.ts
+++ b/src/bill-impact-calculator.ts
@@ -1,0 +1,12 @@
+import { BillImpactCalculator } from './rem/element';
+
+customElements.define(
+  'rewiring-america-bill-impact-calculator',
+  BillImpactCalculator,
+);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rewiring-america-bill-impact-calculator': BillImpactCalculator;
+  }
+}

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -1,11 +1,6 @@
 import { RewiringAmericaCalculator } from './incentives/calculator-element';
-import { BillImpactCalculator } from './rem/element';
 
 customElements.define('rewiring-america-calculator', RewiringAmericaCalculator);
-customElements.define(
-  'rewiring-america-bill-impact-calculator',
-  BillImpactCalculator,
-);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/rem.html
+++ b/src/rem.html
@@ -7,7 +7,7 @@
     <title>Rewiring America Bill Impact Calculator Demo</title>
     <link rel="stylesheet" type="text/css" href="./tailwind.css" />
     <link rel="stylesheet" type="text/css" href="./rewiring-fonts.css" />
-    <script type="module" src="./calculator.ts"></script>
+    <script type="module" src="./bill-impact-calculator.ts"></script>
     <style>
       body {
         -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Description

This makes it so it's not packaged together with the incentives
calculator, cutting the size of the file roughly in half.

## Test Plan

`yarn build:widget`; make sure the standalone file
`bill-impact-calculator.js` gets built.

`yarn serve:widget`; make sure it still works on rem.html.
