### PR TITLE
More detailed & earlier "ending soon" chips for IRA incentives

### DIFF
--- a/src/api/dates.ts
+++ b/src/api/dates.ts
@@ -48,26 +48,34 @@ export function isInFuture(apiDate: string, now: Date): boolean {
 }
 
 /**
- * Returns whether the given API date is within 60 days in the future, relative
- * to "now". (start_date and end_date in the API can represent a range of dates
- * rather than just a single one.)
+ * Returns whether the given API date is within the given number of days in the
+ * future, relative to "now". (start_date and end_date in the API can represent
+ * a range of dates rather than just a single one.)
  *
  * The [now] param will be interpreted in local time.
  */
-export function isChangingSoon(apiDate: string, now: Date): boolean {
+export function isChangingWithinDays(
+  days: number,
+  apiDate: string,
+  now: Date,
+): boolean {
   const earliestPossibleInstant = parseApiDate(apiDate);
   // Construct the timestamp at UTC midnight, with the Y/M/D of now, as
   // interpreted in local time. This avoids timezone issues by only comparing
   // timestamps with the same time and timezone component.
   const utcNow = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
 
-  const sixtyDays = 60 * 24 * 60 * 60 * 1000;
-  const sixtyDaysFromNow = utcNow + sixtyDays;
+  const daysInMilliseconds = days * 24 * 60 * 60 * 1000;
+  const sixtyDaysFromNow = utcNow + daysInMilliseconds;
 
   return (
     earliestPossibleInstant > utcNow &&
     sixtyDaysFromNow > earliestPossibleInstant
   );
+}
+
+export function isExactDay(apiDate: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}/.test(apiDate);
 }
 
 export function getYear(apiDate: string): number {

--- a/src/i18n/strings/es.ts
+++ b/src/i18n/strings/es.ts
@@ -140,6 +140,7 @@ export const templates = {
   s8ff568239ce4b254: `Cuidado del césped`,
   s912b944fa287f7d0: `Nuevo Hampshire`,
   s9a7f0b084a46d64e: `Ingrese su dirección para seleccionar una empresa de servicios eléctricos.`,
+  s9a994af33fff58cd: str`Finaliza el ${0}`,
   s9afee25dcf31efc1: `un vehículo eléctrico nuevo`,
   s9b0d347a81e8f0a3: `Oklahoma`,
   s9ca62f0b7e639157: `Maine`,

--- a/src/i18n/use-translated.ts
+++ b/src/i18n/use-translated.ts
@@ -5,7 +5,7 @@ import { MsgFn, assembleStrResult } from './msg';
 import { TemplatedStr } from './str';
 import { templates as esStrings } from './strings/es';
 
-type Locale = (typeof allLocales)[number];
+export type Locale = (typeof allLocales)[number];
 type TargetLocale = (typeof targetLocales)[number];
 const STRINGS: {
   [k in TargetLocale]: Record<string, string | TemplatedStr>;

--- a/translations/es.xlf
+++ b/translations/es.xlf
@@ -1142,6 +1142,10 @@
 <trans-unit id="s01c0b8cdfb47db52">
   <source>We are unable to estimate bill impacts for this address.</source>
 </trans-unit>
+<trans-unit id="s9a994af33fff58cd">
+  <source>Ending on <x id="0" equiv-text="${formattedDate}"/></source>
+  <target>Finaliza el <x id="0" equiv-text="${formattedDate}"/></target>
+</trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-692)

## Description

We want to prominently highlight the imminent end of the IRA tax
credits, so start showing these chips on federal incentives (all of
which are currently IRA tax credits) 6 months in advance instead of 2,
and include the actual end date in the warning chip.

For non-federal credits, stay at 60 days in advance, but do include
the date in the chip if an exact day is known.

Also I just want to say that Javascript's `Date` is wretched garbage
and I hate it so much argghgh

## Test Plan

Look at the heat pump IRA credits under the HVAC project; make sure
the chip is there and has the right date. Put the embed in Spanish
mode and make sure the chip and date are localized.

Look at the EV charger credit under "transportation" and make sure it
has no chip.
