### PR TITLE
add custom event on submit for the BICalculator

### DIFF
--- a/src/rem/element.tsx
+++ b/src/rem/element.tsx
@@ -172,9 +172,7 @@ const RemCalculator: FC<{
       new CustomEvent('bi-calculator-submitted', {
         bubbles: true,
         composed: true,
-        detail: {
-          formData: formValues,
-        },
+        detail: { formData: { ...formValues, upgrade: upgradeValue } },
       }),
     );
   };

--- a/src/rem/element.tsx
+++ b/src/rem/element.tsx
@@ -103,7 +103,7 @@ const RemCalculator: FC<{
   apiHost: string;
   apiKey: string;
   upgrades: string;
-}> = ({ apiHost, apiKey, upgrades }) => {
+}> = ({ shadowRoot, apiHost, apiKey, upgrades }) => {
   const { msg } = useTranslated();
 
   const parsedUpgrades = parseUpgrades(upgrades);
@@ -167,6 +167,16 @@ const RemCalculator: FC<{
           type: error.type,
         }),
       );
+
+    shadowRoot.dispatchEvent(
+      new CustomEvent('bi-calculator-submitted', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          formData: formValues,
+        },
+      }),
+    );
   };
 
   const resetForm = () => {


### PR DESCRIPTION
## Description
Adds a custom event on submit for the BICalculator that follows the pattern established to the incentives calculator [here](https://github.com/rewiringamerica/embed.rewiringamerica.org/blob/12e28f59ea40cc70bf643e6ff1a567c4a872099a/src/incentives/calculator-element.tsx#L300-L309).

This is to be used to trigger tracking events for users of the embed. 

Code that will leverage this event can be found [here](https://github.com/rewiringamerica/consumer/pull/2488/files#diff-6337d6609038e22638392f1c5087146b3dc71b34a642d8c98796bcbd724d05d2R54-R63). 

## Test Plan
- run `yarn serve:widget`
- navigate to http://localhost:1234/rem
- fill out the form and submit
