### PR TITLE
Accessibility fixes for BIC

### DIFF
--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -1,7 +1,7 @@
 import { flip, offset, useFloating } from '@floating-ui/react-dom';
 import { Listbox, Transition } from '@headlessui/react';
 import clsx from 'clsx';
-import { FC } from 'react';
+import { FC, useId } from 'react';
 import { str } from '../i18n/str';
 import { useTranslated } from '../i18n/use-translated';
 import { FormLabel } from './form-label';
@@ -121,6 +121,8 @@ export const Select = <T extends string>({
     middleware: [flip(), offset(1)],
   });
 
+  const helperTextId = useId();
+
   return (
     <div>
       <Listbox
@@ -158,6 +160,7 @@ export const Select = <T extends string>({
             'rounded',
             'bg-white',
           )}
+          aria-describedby={helperTextId}
         >
           {buttonContents}
           {loading && <Spinner className="w-4 h-4 text-color-text-primary" />}
@@ -232,11 +235,19 @@ export const Select = <T extends string>({
       {
         // nbsp forces vertical space even if text is blank
         errorText ? (
-          <div className="mx-3 mt-1 text-red-500 text-xsm leading-normal">
+          <div
+            id={helperTextId}
+            className="mx-3 mt-1 text-red-500 text-xsm leading-normal"
+            aria-hidden={true}
+          >
             {errorText}&nbsp;
           </div>
         ) : helpText ? (
-          <div className="mx-3 mt-1 text-grey-400 text-xsm leading-normal">
+          <div
+            id={helperTextId}
+            className="mx-3 mt-1 text-grey-400 text-xsm leading-normal"
+            aria-hidden={true}
+          >
             {helpText}&nbsp;
           </div>
         ) : null

--- a/src/components/spinner.tsx
+++ b/src/components/spinner.tsx
@@ -1,10 +1,16 @@
 import clsx from 'clsx';
-import { FC } from 'react';
+import { forwardRef } from 'react';
 
-export const Spinner: FC<{ className?: string }> = ({ className }) => (
+export const Spinner = forwardRef<
+  HTMLDivElement,
+  { className?: string; labelId?: string }
+>(({ className, labelId }, ref) => (
   <div
-    className={clsx(className, 'animate-spinnerContainer')}
+    ref={ref}
+    className={clsx(className, 'animate-spinnerContainer outline-none')}
     role="progressbar"
+    tabIndex={-1}
+    aria-labelledby={labelId}
   >
     <svg className="w-full h-full" viewBox="22 22 44 44">
       <circle
@@ -18,4 +24,4 @@ export const Spinner: FC<{ className?: string }> = ({ className }) => (
       />
     </svg>
   </div>
-);
+));

--- a/src/rem.html
+++ b/src/rem.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/rem/ApproximateResults.tsx
+++ b/src/rem/ApproximateResults.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { RemAddressResponse } from '../api/rem-types';
 import { str } from '../i18n/str';
 import { useTranslated } from '../i18n/use-translated';
@@ -47,10 +47,20 @@ upgrade, but you could still reduce your carbon emissions.`,
       </div>
     );
 
+  // Focus the header on mount, to put screen readers on it
+  const headerRef = useRef<HTMLHeadingElement | null>(null);
+  useEffect(() => {
+    headerRef.current?.focus();
+  });
+
   return (
     <div className="flex flex-col gap-4 p-4 bg-grey-100">
       <div>
-        <h2 className="font-medium leading-normal mb-1">
+        <h2
+          ref={headerRef}
+          className="font-medium leading-normal mb-1"
+          tabIndex={-1}
+        >
           {msg('Bill and emissions impact')}
         </h2>
         <p className="text-sm leading-normal text-grey-600">

--- a/src/rem/DetailedResults.tsx
+++ b/src/rem/DetailedResults.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { Quantiles, RemAddressResponse } from '../api/rem-types';
 import { str } from '../i18n/str';
 import { useTranslated } from '../i18n/use-translated';
@@ -161,10 +161,20 @@ export const DetailedResults: FC<{ savings: RemAddressResponse }> = ({
     />
   );
 
+  // Focus the header on mount, to put screen readers on it
+  const headerRef = useRef<HTMLHeadingElement | null>(null);
+  useEffect(() => {
+    headerRef.current?.focus();
+  });
+
   return (
     <div className="flex flex-col gap-4 p-4 bg-grey-100">
       <div>
-        <h2 className="font-medium leading-normal mb-1">
+        <h2
+          ref={headerRef}
+          className="font-medium leading-normal mb-1"
+          tabIndex={-1}
+        >
           {msg('Bill and emissions impact')}
         </h2>
         <p className="text-sm leading-normal">

--- a/src/rem/RemForm.tsx
+++ b/src/rem/RemForm.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { FC, useEffect, useRef } from 'react';
+import { FC, useEffect, useId, useRef } from 'react';
 import { HeatingFuel, RemErrorType, WaterHeatingFuel } from '../api/rem-types';
 import { TextButton } from '../components/buttons';
 import { FormLabel } from '../components/form-label';
@@ -174,6 +174,7 @@ export const RemForm: FC<{
     'Enter your street address, city, state, and ZIP code.',
   );
   const addressFieldRef = useRef<HTMLInputElement>(null);
+  const addressDescriptionId = useId();
 
   // Focus the address field if there's a new error
   useEffect(() => {
@@ -239,8 +240,11 @@ export const RemForm: FC<{
             onChange={e =>
               onValuesChange({ ...values, address: e.target.value })
             }
+            aria-describedby={addressDescriptionId}
           />
           <div
+            id={addressDescriptionId}
+            aria-hidden={true}
             className={clsx(
               'mx-3 mt-1 text-xsm leading-normal',
               addressErrorText ? 'text-red-500' : 'text-grey-400',

--- a/src/rem/UpgradeOptions.tsx
+++ b/src/rem/UpgradeOptions.tsx
@@ -74,16 +74,15 @@ export const UpgradeOptions: FC<{
           'flex flex-col p-3 gap-2 text-left',
           'first:rounded-t-xl last:rounded-b-xl',
           'border-b border-grey-200 last:border-0',
-          disabled && 'opacity-35',
+          'disabled:opacity-35',
           checked ? 'bg-purple-100' : 'bg-white',
         )}
         type="button"
         onClick={() => !disabled && onUpgradeSelected(upgrade)}
-        tabIndex={disabled ? -1 : 0}
+        disabled={disabled}
         value={upgrade}
         role="radio"
         aria-checked={checked}
-        aria-disabled={disabled}
         aria-labelledby={labelId}
         aria-describedby={descriptionId}
       >

--- a/src/rem/element.tsx
+++ b/src/rem/element.tsx
@@ -1,5 +1,5 @@
 import tailwindStyles from 'bundle-text:../tailwind.css';
-import { FC, useState } from 'react';
+import { FC, useEffect, useId, useRef, useState } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import { DEFAULT_CALCULATOR_API_HOST, fetchApi } from '../api/fetch';
 import { FetchState } from '../api/fetch-state';
@@ -56,6 +56,7 @@ const Header = () => {
         src={new URL('../../static/logo.png', import.meta.url).toString()}
         width="61"
         height="20"
+        aria-hidden={true}
       />
       <span className="text-sm font-medium leading-normal">
         {msg('Bill Impact Calculator')}
@@ -66,15 +67,26 @@ const Header = () => {
 
 const Loading = () => {
   const { msg } = useTranslated();
+  const labelId = useId();
+
+  // Focus the spinner when it first appears on the page
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    ref.current?.focus();
+  });
+
   return (
     <div
       key="spinner"
       className="bg-grey-100 p-4 flex flex-col items-center py-12 gap-4"
     >
       <div className="w-25 h-25 text-grey-400">
-        <Spinner />
+        <Spinner ref={ref} labelId={labelId} />
       </div>
-      <div className="text-grey-400 text-lg font-medium leading-tight">
+      <div
+        id={labelId}
+        className="text-grey-400 text-lg font-medium leading-tight"
+      >
         {msg('Calculating impact...')}
       </div>
     </div>


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-737)

## Description

- Hide the RA logo at the top from screen readers (it's purely decorative)

- Put the `lang` attribute on the `html` element of the demo page

- The address and WH fuel helper texts come after their respective
  fields in the tab order, which is a weird experience for screen
  readers. Make the form fields `aria-describedby` those texts, and
  hide the texts from the screen reader.

- Focus both the spinner and the "bill and emissions impact" header
  when they appear on the page, to prevent both keyboard and screen
  reader from losing their place when the React components swap out.

- Tweak the disabled radio button implementation a little bit for
  better semantics; this has the visible consequence that the cursor
  is no longer a pointer when hovering a disabled radio button.

The only remaining issues, AFAIK, are some potential color-contrast
issues, which I'll address separately.

## Test Plan

Run through the flow with a screen reader (VoiceOver) and make sure:

- It ignores the logo

- It reads out the helper texts of the address and WH fuel fields
  while you're focused on the form controls themselves, and then does
  not stop on the helper text

- After clicking the calculate button, it announces the indeterminate
  progress indicator and "calculating impact"

- After results load, it focuses on the header, from which you can go
  down to the actual results

Mouse over the disabled HPWH option (don't have a WH fuel selected)
and make sure the cursor is not a pointing hand.
