### PR TITLE
Fix color contrast issues for a11y; add basic Cypress test

### DIFF
--- a/cypress/e2e/bill-impact-calculator.cy.ts
+++ b/cypress/e2e/bill-impact-calculator.cy.ts
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+/// <reference types="cypress-axe" />
+
+describe('bill impact calculator', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:1234/rem.html');
+
+    // Inject the axe-core library
+    cy.injectAxe();
+  });
+
+  it('renders the calculator', () => {
+    cy.get('rewiring-america-bill-impact-calculator').should('exist');
+
+    cy.get('rewiring-america-bill-impact-calculator')
+      .shadow()
+      .contains('Your household info');
+  });
+
+  it('has no detectable a11y violations on load', () => {
+    cy.get('rewiring-america-bill-impact-calculator')
+      .shadow()
+      .checkA11y(null, {
+        runOnly: ['wcag2a', 'wcag2aa'],
+      });
+  });
+});

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -237,12 +237,20 @@ export const EditIcon: FC<IconProps> = ({ w, h }) => (
   </svg>
 );
 
-export const RadioButton: FC<IconProps & { selected: boolean }> = ({
-  w,
-  h,
-  selected,
-}) =>
-  selected ? (
+export const RadioButton: FC<
+  IconProps & { selected: boolean; disabled?: boolean }
+> = ({ w, h, selected, disabled }) =>
+  disabled ? (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={w}
+      height={h}
+      viewBox="0 0 22 22"
+      fill="none"
+    >
+      <circle cx="11" cy="11" r="10" stroke="#9b9b9b" strokeWidth="2" />
+    </svg>
+  ) : selected ? (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={w}

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -245,7 +245,7 @@ export const Select = <T extends string>({
         ) : helpText ? (
           <div
             id={helperTextId}
-            className="mx-3 mt-1 text-grey-400 text-xsm leading-normal"
+            className="mx-3 mt-1 text-grey-500 text-xsm leading-normal"
             aria-hidden={true}
           >
             {helpText}&nbsp;

--- a/src/rem/RemForm.tsx
+++ b/src/rem/RemForm.tsx
@@ -247,7 +247,7 @@ export const RemForm: FC<{
             aria-hidden={true}
             className={clsx(
               'mx-3 mt-1 text-xsm leading-normal',
-              addressErrorText ? 'text-red-500' : 'text-grey-400',
+              addressErrorText ? 'text-red-500' : 'text-grey-500',
             )}
           >
             {addressErrorText ?? addressHelpText}

--- a/src/rem/UpgradeOptions.tsx
+++ b/src/rem/UpgradeOptions.tsx
@@ -73,10 +73,10 @@ export const UpgradeOptions: FC<{
       <button
         key={upgrade}
         className={clsx(
+          'group',
           'flex flex-col p-3 gap-2 text-left',
           'first:rounded-t-xl last:rounded-b-xl',
           'border-b border-grey-200 last:border-0',
-          'disabled:opacity-35',
           checked ? 'bg-purple-100' : 'bg-white',
         )}
         type="button"
@@ -89,12 +89,18 @@ export const UpgradeOptions: FC<{
         aria-describedby={descriptionId}
       >
         <div className="flex w-full justify-between">
-          <h2 id={labelId} className="font-medium leading-tight">
+          <h2
+            id={labelId}
+            className="font-medium leading-tight text-grey-900 group-disabled:text-grey-300"
+          >
             {getLabelForUpgrade(upgrade, msg)}
           </h2>
-          <RadioButton w={22} h={22} selected={checked} />
+          <RadioButton w={22} h={22} selected={checked} disabled={disabled} />
         </div>
-        <p id={descriptionId} className="text-sm text-grey-600 leading-normal">
+        <p
+          id={descriptionId}
+          className="text-sm text-grey-600 group-disabled:text-grey-300 leading-normal"
+        >
           {DESCRIPTIONS[upgrade](msg)}
         </p>
       </button>,


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-737)

## Description

The helper texts in the form didn't have enough contrast with the
background, so make them grey-500 instead of 400. (The change to
`<Select>` affects the incentives embed too, where it's against a
white background instead of grey-100, but to my eye it looks fine the
new way.)

The disabled state of the upgrade option looked even less contrast-y
to my eye, but automated tools didn't catch it (cypress-axe or
Lighthouse). We're changing it anyway, to just lighten the text
instead of changing opacity.

I added a very basic Cypress test that doesn't manipulate the page in
any way, just runs a11y checks on the blank state. I don't really want
to have the Cypress test making real API requests because they're
quite slow (much slower than incentives). Instead I want to mock the
requests out, but I'd rather figure that out separately.

## Test Plan

New Cypress test passes. Helper text and disabled state look OK.
