### PR TITLE
Fix several little BIC bugs

### DIFF
--- a/src/components/text-input.tsx
+++ b/src/components/text-input.tsx
@@ -33,6 +33,6 @@ export const TextInput = forwardRef<
       'focus:outline-purple-500',
       props.inputMode === 'numeric' && 'tabular-nums',
     )}
-    {...props}
+    {...{ ...props, error: undefined }}
   />
 ));

--- a/src/rem/RemForm.tsx
+++ b/src/rem/RemForm.tsx
@@ -159,15 +159,14 @@ export const RemForm: FC<{
   errorType: RemErrorType | null;
   values: RemFormValues;
   onValuesChange: (v: RemFormValues) => void;
+  canReset: boolean;
   onReset: () => void;
-}> = ({ errorType, values, onValuesChange, onReset }) => {
+}> = ({ errorType, values, onValuesChange, canReset, onReset }) => {
   const { msg } = useTranslated();
 
   const { buildingType, address, heatingFuel, waterHeatingFuel } = values;
 
   const isBadBuildingType = buildingType === BuildingType.Apartment;
-  const areValuesModified =
-    !!buildingType || !!address || !!heatingFuel || !!waterHeatingFuel;
 
   const addressErrorText = errorType ? getErrorText(errorType, msg) : null;
   const addressHelpText = msg(
@@ -190,11 +189,7 @@ export const RemForm: FC<{
           {msg('Your household info')}
         </h1>
         <div>
-          <TextButton
-            disabled={!areValuesModified}
-            type="reset"
-            onClick={onReset}
-          >
+          <TextButton disabled={!canReset} type="reset" onClick={onReset}>
             {msg('Reset')}
           </TextButton>
         </div>

--- a/src/rem/element.tsx
+++ b/src/rem/element.tsx
@@ -210,8 +210,16 @@ const RemCalculator: FC<{
       !!formValues.heatingFuel &&
       !!upgradeValue;
 
+    const canReset =
+      !!formValues.buildingType ||
+      !!formValues.address ||
+      !!formValues.heatingFuel ||
+      !!formValues.waterHeatingFuel ||
+      !!upgradeValue;
+
     children.push(
       <form
+        key="form"
         className="flex flex-col m-0 bg-grey-100"
         onSubmit={e => {
           e.preventDefault();
@@ -219,7 +227,6 @@ const RemCalculator: FC<{
         }}
       >
         <RemForm
-          key="form"
           errorType={
             fetchState.state === 'error'
               ? (fetchState.type as RemErrorType)
@@ -237,11 +244,11 @@ const RemCalculator: FC<{
               setUpgradeValue(null);
             }
           }}
+          canReset={canReset}
           onReset={resetForm}
         />
         <div className="h-px mx-4 bg-grey-200">{/* separator */}</div>
         <UpgradeOptions
-          key="upgradeOptions"
           upgrades={parsedUpgrades}
           includeWaterHeater={!!formValues.waterHeatingFuel}
           selectedUpgrade={upgradeValue}
@@ -282,19 +289,13 @@ const RemCalculator: FC<{
     }
   }
 
-  children.push(
-    <div
-      key="footer"
-      className="bg-white text-sm px-4 py-3 leading-normal text-center"
-    >
-      <FooterCopy />
-    </div>,
-  );
-
   return (
     <div className="flex flex-col gap-px bg-grey-200 rounded-xl border border-grey-200 overflow-clip">
       <Header />
       {children}
+      <div className="bg-white text-sm px-4 py-3 leading-normal text-center">
+        <FooterCopy />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

- Fix some React warnings about elements in a list not having keys.

- Fix a custom prop on TextInput incorrectly being passed along to the
  underlying `<input>`.

- Enable the reset button when the only thing that's changed from the
  blank state is an upgrade being selected. This required pulling the
  "is there anything to reset" logic up into the main element.

## Test Plan

- Run through the flow while looking at the console, and make sure
  there are no errors.

- Reset the form, click an upgrade, and make sure the reset button is
  enabled.
