### PR TITLE
Don't add the stylesheet with appendChild

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ rewiring-america-state-calculator {
 
 The calculator defines and uses many other CSS variables, but **their existence and behavior are not guaranteed to be stable**; override them at your own risk. Only variables prefixed with `--ra-` are supported customization points.
 
+### `Content-Security-Policy` directives
+
+To enforce a CSP on a page that embeds the calculator, you'll need the following directives in your CSP:
+
+- `script-src https://embed.rewiringamerica.org/`
+- `style-src https://embed.rewiringamerica.org/`
+- `font-src https://www.rewiringamerica.org/`
+- `connect-src https://api.rewiringamerica.org/`
+
 ## Usage — Bill Impact Calculator
 
 To embed the bill impact calculator on your website:
@@ -157,6 +166,10 @@ The events' `target` is the calculator component. They are not cancelable. You c
 | Event name                | `detail`                                                                                                                                                                                       |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bi-calculator-submitted` | The key `formData` contains an object with the form data that was submitted. The possible keys in that object are `buildingType`, `address`, `heatingFuel`, `waterHeatingFuel`, and `upgrade`. |
+
+### `Content-Security-Policy` directives
+
+To enforce a CSP on a page that embeds the calculator, you'll need the same directives as for the incentives calculator, [documented above](#content-security-policy-directives).
 
 ## Running / building
 

--- a/package.json
+++ b/package.json
@@ -103,5 +103,6 @@
   },
   "lint-staged": {
     "**/*.{js,ts,tsx,json,md,css,html}": "prettier --write"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/bill-impact-calculator.html
+++ b/src/bill-impact-calculator.html
@@ -5,10 +5,13 @@
     <!-- TODO remove this when the widget is launched -->
     <meta name="robots" content="noindex" />
     <title>Rewiring America Bill Impact Calculator Demo</title>
-    <link rel="stylesheet" type="text/css" href="./tailwind.css" />
     <link rel="stylesheet" type="text/css" href="./rewiring-fonts.css" />
     <script type="module" src="./bill-impact-calculator.ts"></script>
     <style>
+      @tailwind base;
+      @tailwind components;
+      @tailwind utilities;
+
       body {
         -webkit-font-smoothing: antialiased;
         -moz-font-smoothing: antialiased;

--- a/src/incentives/calculator-element.tsx
+++ b/src/incentives/calculator-element.tsx
@@ -1,4 +1,3 @@
-import tailwindStyles from 'bundle-text:../tailwind.css';
 import { FC, useEffect, useRef, useState } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -499,10 +498,11 @@ export class RewiringAmericaCalculator extends HTMLElement {
     if (!this.shadowRoot) {
       const shadowRoot = this.attachShadow({ mode: 'open' });
 
-      const style = document.createElement('style');
-      style.textContent = tailwindStyles;
-
-      shadowRoot.appendChild(style);
+      const stylesheet = document.createElement('link');
+      stylesheet.href = new URL('../tailwind.css', import.meta.url).toString();
+      stylesheet.rel = 'stylesheet';
+      stylesheet.type = 'text/css';
+      shadowRoot.appendChild(stylesheet);
 
       const calculator = document.createElement('div');
       shadowRoot.appendChild(calculator);

--- a/src/parcel.d.ts
+++ b/src/parcel.d.ts
@@ -1,8 +1,3 @@
-declare module 'bundle-text:*' {
-  const value: string;
-  export default value;
-}
-
 /**
  * Import an SVG file as "jsx:./path/to/icon.svg" to import it as if it were a
  * JSX <svg> element. This is done with a Parcel transformer.

--- a/src/rem/element.tsx
+++ b/src/rem/element.tsx
@@ -1,4 +1,3 @@
-import tailwindStyles from 'bundle-text:../tailwind.css';
 import { FC, useEffect, useId, useRef, useState } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import { DEFAULT_CALCULATOR_API_HOST, fetchApi } from '../api/fetch';
@@ -360,10 +359,11 @@ export class BillImpactCalculator extends HTMLElement {
     if (!this.shadowRoot) {
       const shadowRoot = this.attachShadow({ mode: 'open' });
 
-      const style = document.createElement('style');
-      style.textContent = tailwindStyles;
-
-      shadowRoot.appendChild(style);
+      const stylesheet = document.createElement('link');
+      stylesheet.href = new URL('../tailwind.css', import.meta.url).toString();
+      stylesheet.rel = 'stylesheet';
+      stylesheet.type = 'text/css';
+      shadowRoot.appendChild(stylesheet);
 
       const calculator = document.createElement('div');
       shadowRoot.appendChild(calculator);


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-679)

## Description

We have a potential embedder who wants to embed the calculator on a
page with a locked-down Content-Security-Policy. However, the
calculator loads its stylesheet by creating a `<style>` DOM node in JS
and appending it to the DOM tree, and the only way that can pass a CSP
is with an `unsafe-inline` directive, which defeats the purpose.

This switches to using a `<link>` tag to load the stylesheet, which
can pass a `style-src` directive in a CSP.

The change to `bill-impact-calculator.html` to remove the `<link>` to
the stylesheet is not incidental; it's required to make this work. I
believe this is a quirk (bug?) of Parcel, but if I keep that link
there, the code that loads the stylesheets in the calculator elements
fails in dev mode, with an "invalid URL" error.

## Test Plan

Look at the preview deploy of this branch and make sure it has the
right styles and works correctly.

I pushed another branch (`owen.csp-test2`) in which I put a `<meta
http-equiv="Content-Security-Policy" ... />` tag on `index.html`, with
the directives I put in the README.

First I changed index.html on that branch to load
`state-calculator.js` and `rewiring-fonts.css` from
`https://embed.rewiringamerica.org` (instead of using relative
paths). I made sure the calculator failed to load due to CSP errors,
and confirmed that the `appendChild` of the stylesheet was the failing
line of code.

Then I changed index.html to load the JS and CSS files from this PR's
branch deploy, updated the domains in the meta tag's CSP directive
accordingly, and made sure the calculator loads, looks correct, and
functions (including making API calls successfully).
