### PR TITLE
Second attempt at using <link> to load CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ rewiring-america-state-calculator {
 
 The calculator defines and uses many other CSS variables, but **their existence and behavior are not guaranteed to be stable**; override them at your own risk. Only variables prefixed with `--ra-` are supported customization points.
 
+### `Content-Security-Policy` directives
+
+The calculator loads JavaScript and CSS from `https://embed.rewiringamerica.org`, loads fonts from `https://www.rewiringamerica.org`, and makes `fetch()` calls to `https://api.rewiringamerica.org`.
+
+Therefore, to enforce a CSP on a page that embeds the calculator, you'll need the following directives (or something more permissive) in your CSP:
+
+- `script-src https://embed.rewiringamerica.org/`
+- `style-src https://embed.rewiringamerica.org/`
+- `font-src https://www.rewiringamerica.org/`
+- `connect-src https://api.rewiringamerica.org/`
+
 ## Usage — Bill Impact Calculator
 
 To embed the bill impact calculator on your website:
@@ -157,6 +168,12 @@ The events' `target` is the calculator component. They are not cancelable. You c
 | Event name                | `detail`                                                                                                                                                                                       |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bi-calculator-submitted` | The key `formData` contains an object with the form data that was submitted. The possible keys in that object are `buildingType`, `address`, `heatingFuel`, `waterHeatingFuel`, and `upgrade`. |
+
+### `Content-Security-Policy` directives
+
+To enforce a CSP on a page that embeds the calculator, you'll need the same directives as for the incentives calculator, [documented above](#content-security-policy-directives), as well as one additional:
+
+- `img-src https://embed.rewiringamerica.org/`
 
 ## Running / building
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "build": "parcel build src/package-index.ts",
-    "build:widget": "parcel build --target default",
-    "serve:widget": "parcel serve ./src/*.html --dist-dir build",
+    "build:widget": "parcel build --target default && cp dist/state-calculator.js dist/calculator.js",
+    "serve:widget": "parcel serve --target default --dist-dir build",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "lint": "tsc --noEmit && prettier --check . && eslint .",
@@ -88,7 +88,6 @@
     "default": {
       "source": [
         "src/bill-impact-calculator.ts",
-        "src/calculator.ts",
         "src/state-calculator.ts",
         "src/rewiring-fonts.css",
         "src/bill-impact-calculator.html",
@@ -103,5 +102,6 @@
   },
   "lint-staged": {
     "**/*.{js,ts,tsx,json,md,css,html}": "prettier --write"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/bill-impact-calculator.html
+++ b/src/bill-impact-calculator.html
@@ -2,12 +2,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- TODO remove this when the widget is launched -->
-    <meta name="robots" content="noindex" />
-    <title>Rewiring America Bill Impact Calculator Demo</title>
     <link rel="stylesheet" type="text/css" href="./tailwind.css" />
     <link rel="stylesheet" type="text/css" href="./rewiring-fonts.css" />
-    <script type="module" src="./bill-impact-calculator.ts"></script>
+    <title>Rewiring America Bill Impact Calculator Demo</title>
     <style>
       body {
         -webkit-font-smoothing: antialiased;
@@ -33,7 +30,11 @@
         >.
       </p>
       <div class="bg-[#e2e2e2] my-4 h-px"></div>
-      <rewiring-america-bill-impact-calculator api-key="{{ apiKey }}" />
+      <rewiring-america-bill-impact-calculator
+        api-key="{{ apiKey }}"
+      ></rewiring-america-bill-impact-calculator>
+
+      <script type="module" src="./bill-impact-calculator.ts"></script>
     </main>
   </body>
 </html>

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -1,9 +1,0 @@
-import { RewiringAmericaCalculator } from './incentives/calculator-element';
-
-customElements.define('rewiring-america-calculator', RewiringAmericaCalculator);
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'rewiring-america-calculator': RewiringAmericaCalculator;
-  }
-}

--- a/src/incentives/calculator-element.tsx
+++ b/src/incentives/calculator-element.tsx
@@ -1,4 +1,3 @@
-import tailwindStyles from 'bundle-text:../tailwind.css';
 import { FC, useEffect, useRef, useState } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -499,10 +498,11 @@ export class RewiringAmericaCalculator extends HTMLElement {
     if (!this.shadowRoot) {
       const shadowRoot = this.attachShadow({ mode: 'open' });
 
-      const style = document.createElement('style');
-      style.textContent = tailwindStyles;
-
-      shadowRoot.appendChild(style);
+      const stylesheet = document.createElement('link');
+      stylesheet.href = new URL('../tailwind.css', import.meta.url).toString();
+      stylesheet.rel = 'stylesheet';
+      stylesheet.type = 'text/css';
+      shadowRoot.appendChild(stylesheet);
 
       const calculator = document.createElement('div');
       shadowRoot.appendChild(calculator);

--- a/src/incentives/state-calculator-form.tsx
+++ b/src/incentives/state-calculator-form.tsx
@@ -262,12 +262,8 @@ export const CalculatorForm: FC<{
 }) => {
   const { msg } = useTranslated();
 
-  const [address, setAddress] = useState(
-    showAddressField ? initialValues.address : undefined,
-  );
-  const [zip, setZip] = useState(
-    showAddressField ? undefined : initialValues.zip,
-  );
+  const [address, setAddress] = useState(initialValues.address ?? '');
+  const [zip, setZip] = useState(initialValues.zip);
   const [ownerStatus, setOwnerStatus] = useState(initialValues.ownerStatus);
   const [householdIncome, setHouseholdIncome] = useState(
     initialValues.householdIncome,
@@ -365,8 +361,7 @@ export const CalculatorForm: FC<{
       onSubmit={e => {
         e.preventDefault();
         const values: FormValues = {
-          address: showAddressField ? address : undefined,
-          zip: showAddressField ? undefined : zip,
+          ...(showAddressField ? { address } : { zip }),
           ownerStatus,
           householdIncome,
           householdSize,
@@ -378,8 +373,7 @@ export const CalculatorForm: FC<{
 
         const gasOptions = getGasOptions(utilitiesFetchState, msg);
         const labels: FormLabels = {
-          address: showAddressField ? address : undefined,
-          zip: showAddressField ? undefined : zip,
+          ...(showAddressField ? { address } : { zip }),
           householdIncome: AutoNumeric.format(householdIncome, {
             ...AutoNumeric.getPredefinedOptions().NorthAmerican,
             decimalPlaces: 0,

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,6 @@
     />
     <meta name="robots" content="noindex" />
     <title>Rewiring America Incentives Calculator Demo</title>
-    <script type="module" src="./state-calculator.ts"></script>
     <link rel="stylesheet" type="text/css" href="./rewiring-fonts.css" />
     <style>
       html,
@@ -108,6 +107,8 @@
         owner-status="homeowner"
         include-beta-states
       ></rewiring-america-state-calculator>
+
+      <script type="module" src="./state-calculator.ts"></script>
     </main>
   </body>
 </html>

--- a/src/parcel.d.ts
+++ b/src/parcel.d.ts
@@ -1,8 +1,3 @@
-declare module 'bundle-text:*' {
-  const value: string;
-  export default value;
-}
-
 /**
  * Import an SVG file as "jsx:./path/to/icon.svg" to import it as if it were a
  * JSX <svg> element. This is done with a Parcel transformer.

--- a/src/rem/element.tsx
+++ b/src/rem/element.tsx
@@ -1,4 +1,3 @@
-import tailwindStyles from 'bundle-text:../tailwind.css';
 import { FC, useEffect, useId, useRef, useState } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import { DEFAULT_CALCULATOR_API_HOST, fetchApi } from '../api/fetch';
@@ -360,10 +359,11 @@ export class BillImpactCalculator extends HTMLElement {
     if (!this.shadowRoot) {
       const shadowRoot = this.attachShadow({ mode: 'open' });
 
-      const style = document.createElement('style');
-      style.textContent = tailwindStyles;
-
-      shadowRoot.appendChild(style);
+      const stylesheet = document.createElement('link');
+      stylesheet.href = new URL('../tailwind.css', import.meta.url).toString();
+      stylesheet.rel = 'stylesheet';
+      stylesheet.type = 'text/css';
+      shadowRoot.appendChild(stylesheet);
 
       const calculator = document.createElement('div');
       shadowRoot.appendChild(calculator);

--- a/src/state-calculator.ts
+++ b/src/state-calculator.ts
@@ -1,8 +1,21 @@
 import { RewiringAmericaCalculator } from './incentives/calculator-element';
 
+// There are two custom component names in use in the wild; support both of
+// them here.
 customElements.define(
   'rewiring-america-state-calculator',
   RewiringAmericaCalculator,
+);
+
+// Clients using this tag will be importing "/calculator.js". We don't build
+// that file using Parcel; it's just a copy of the built version of this file.
+// This is a workaround for a Parcel bug.
+// See https://github.com/parcel-bundler/parcel/issues/10213
+customElements.define(
+  'rewiring-america-calculator',
+  // Have to define a separate class, because it's an error to define() two
+  // different names to the same constructor.
+  class extends RewiringAmericaCalculator {},
 );
 
 /**
@@ -12,5 +25,6 @@ customElements.define(
 declare global {
   interface HTMLElementTagNameMap {
     'rewiring-america-state-calculator': RewiringAmericaCalculator;
+    'rewiring-america-calculator': RewiringAmericaCalculator;
   }
 }


### PR DESCRIPTION
## Links

- [Jira](https://rewiringamerica.atlassian.net/browse/RAT-679)
- [Parcel bug report](https://github.com/parcel-bundler/parcel/issues/10213)

## Description

This is a repeat of #281 (which was since reverted as #283), but with
a workaround for a Parcel bug that it triggered. (I've filed a bug
report on Parcel, linked above.)

The problem with the original PR was that Parcel turned the
`new URL('../tailwind.css', import.meta.url)` calls into an invalid URL
**if** the `<script>` tag that loaded the embed JS appeared on the
page **after** the embed element itself. This meant that the
calculator UI components all showed up and were fully functional, but
they were unstyled.

For whatever reason, this bug goes away if I remove
`src/calculator.ts` from the list of files for Parcel to build. So I
did that. To continue supporting embedders who are loading the embed
JS from `/calculator.js` and using the custom tag
`rewiring-america-calculator`, the file `state-calculator.js` now
defines both custom tags, and we manually copy that file to
`calculator.js` immediately after running `parcel build`.

To make sure we're poking this bug during development, I updated the
`serve:widget` command to be as close as possible to the prod build
command, and moved the script tags on the demo pages to be after the
custom components.

This whole situation feels upsettingly brittle, so I'll keep an eye on
that Parcel bug report and possibly see if I can fix it myself.

## Test Plan

(Try just reverting #283 and doing the below steps to repro the bug)

- Run `yarn build:widget` and `npx serve dist`. This serves the built
  artifacts on port 3000.

- In a separate directory, create an HTML page with the
  state-calculator custom component on it, put the `<script>` tag
  below it, loading from `http://localhost:3000/state-calculator.js`.

- Run `npx serve` in that separate directory, then go to the URL it
  prints in a browser. Make sure the calculator shows up and is
  properly styled.

- Change the script tag to load `http://localhost:3000/calculator.js`,
  change the HTML tag to `rewiring-america-calculator`, and make sure
  that still brings up the calculator, correctly styled.

- Change the script tag to load
  `http://localhost:3000/bill-impact-calculator.js`, change the HTML
  tag to `rewiring-america-bill-impact-calculator`, and make sure that
  brings up BIC, correctly styled (and the logo appears at the top).

Then repeat the test plan from #281 to test the CSP part.
