### PR TITLE
Add campaign slot

### DIFF
--- a/src/incentives/state-incentive-details.tsx
+++ b/src/incentives/state-incentive-details.tsx
@@ -345,6 +345,7 @@ export const IncentiveGrid = ({
           }}
         />
       </div>
+      <slot name="campaign">{/* Campaign content can be inserted here */}</slot>
       {projectTab !== null ? (
         <CardCollection
           incentives={incentivesByProject[projectTab]}


### PR DESCRIPTION
## Description

To support the SOBA/3rd-party referral campaign, adds a slot that can support components dropped into the main RA savings calculator.

## Test Plan

Not much to test on this end-- an upcoming PR in consumer will drop the campaign component in, so the campaign code can live there.